### PR TITLE
[GJ-18] Add a fake result for TPC-H Q6

### DIFF
--- a/cpp/src/proto/substrait_utils.cc
+++ b/cpp/src/proto/substrait_utils.cc
@@ -294,12 +294,10 @@ class SubstraitParser::WholeStageResultIterator
         arrow::internal::checked_cast<arrow::DoubleBuilder*>(array_builder.release()));
   }
 
-  bool HasNext() override {
-    return has_next_;
-  }
+  bool HasNext() override { return has_next_; }
 
   arrow::Status Next(std::shared_ptr<arrow::RecordBatch>* out) override {
-    double res = 6553665536.18;
+    double res = 10000;
     builder_->Append(res);
     std::shared_ptr<arrow::Array> array;
     auto status = builder_->Finish(&array);

--- a/jvm/src/main/scala/com/intel/oap/extension/columnar/ColumnarGuardRule.scala
+++ b/jvm/src/main/scala/com/intel/oap/extension/columnar/ColumnarGuardRule.scala
@@ -285,6 +285,10 @@ case class TransformGuardRule() extends Rule[SparkPlan] {
         insertRowGuard(plan)
       case p: BroadcastQueryStageExec =>
         p
+      // FIXME: A tmp workaround for single Agg
+      case a: HashAggregateExec
+        if !a.child.isInstanceOf[ProjectExec] && !a.child.isInstanceOf[FilterExec] =>
+        insertRowGuard(a)
       case other =>
         other.withNewChildren(other.children.map(insertRowGuardOrNot))
     }


### PR DESCRIPTION
This pr 

- added a fake result for TPC-H Q6 for easier debug.
- fallbacked the second stage of TPC-H Q6.

For each Partition, a fake result (res = 10000) will be returned as the output the first stage. The correct final result would be equal to `numPartitions * res`.

https://github.com/oap-project/gazelle-jni/issues/18