### PR TITLE
[GJ-23] Make CPP compilation and library name configurable

### DIFF
--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -2,15 +2,17 @@
 
 set -eu
 
-TESTS=${1:-OFF}
-BUILD_ARROW=${2:-ON}
-STATIC_ARROW=${3:-OFF}
-BUILD_PROTOBUF=${4:-ON}
-ARROW_ROOT=${5:-/usr/local}
-ARROW_BFS_INSTALL_DIR=${6}
-BUILD_JEMALLOC=${7:-ON}
+BUILD_CPP=${1:-ON}
+TESTS=${2:-OFF}
+BUILD_ARROW=${3:-ON}
+STATIC_ARROW=${4:-OFF}
+BUILD_PROTOBUF=${5:-ON}
+ARROW_ROOT=${6:-/usr/local}
+ARROW_BFS_INSTALL_DIR=${7}
+BUILD_JEMALLOC=${8:-ON}
 
 echo "CMAKE Arguments:"
+echo "BUILD_CPP=${BUILD_CPP}"
 echo "TESTS=${TESTS}"
 echo "BUILD_ARROW=${BUILD_ARROW}"
 echo "STATIC_ARROW=${STATIC_ARROW}"
@@ -21,11 +23,12 @@ echo "BUILD_JEMALLOC=${BUILD_JEMALLOC}"
 
 CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 echo $CURRENT_DIR
-
 cd ${CURRENT_DIR}
 if [ -d build ]; then
     rm -r build
 fi
+
+if [ $BUILD_CPP == "ON" ]; then
 mkdir build
 cd build
 cmake .. -DTESTS=${TESTS} -DBUILD_ARROW=${BUILD_ARROW} -DSTATIC_ARROW=${STATIC_ARROW} -DBUILD_PROTOBUF=${BUILD_PROTOBUF} -DARROW_ROOT=${ARROW_ROOT} -DARROW_BFS_INSTALL_DIR=${ARROW_BFS_INSTALL_DIR} -DBUILD_JEMALLOC=${BUILD_JEMALLOC}
@@ -36,4 +39,4 @@ set +eu
 make -j2
 
 set +eu
-
+fi

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -36,13 +36,8 @@
     <hive.parquet.group>com.twitter</hive.parquet.group>
     <parquet.deps.scope>provided</parquet.deps.scope>
     <jars.target.dir>${project.build.directory}/scala-${scala.binary.version}/jars</jars.target.dir>
-    <jvm.cpp_tests>${cpp_tests}</jvm.cpp_tests>
     <jvm.build_arrow>OFF</jvm.build_arrow>
-    <jvm.static_arrow>${static_arrow}</jvm.static_arrow>
     <jvm.arrow.bfs.install.dir>${project.basedir}/../tools/build/arrow_install</jvm.arrow.bfs.install.dir>
-    <jvm.arrow_root>${arrow_root}</jvm.arrow_root>
-    <jvm.build_protobuf>${build_protobuf}</jvm.build_protobuf>
-    <jvm.build_jemalloc>${build_jemalloc}</jvm.build_jemalloc>
     <!-- protobuf paths -->
     <protobuf.input.directory>${project.basedir}/src/main/java/com/intel/oap/substrait/binary</protobuf.input.directory>
     <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
@@ -378,13 +373,14 @@
                     <executable>bash</executable>
                     <arguments>
                         <argument>${cpp.dir}/compile.sh</argument>
-                        <argument>${jvm.cpp_tests}</argument>
+                        <argument>${build_cpp}</argument>
+                        <argument>${cpp_tests}</argument>
                         <argument>${jvm.build_arrow}</argument>
-                        <argument>${jvm.static_arrow}</argument>
-                        <argument>${jvm.build_protobuf}</argument>
-                        <argument>${jvm.arrow_root}</argument>
+                        <argument>${static_arrow}</argument>
+                        <argument>${build_protobuf}</argument>
+                        <argument>${arrow_root}</argument>
                         <argument>${jvm.arrow.bfs.install.dir}</argument>
-                        <argument>${jvm.build_jemalloc}</argument>
+                        <argument>${build_jemalloc}</argument>
                     </arguments>
                 </configuration>
             </execution>

--- a/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluator.java
+++ b/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluator.java
@@ -52,11 +52,15 @@ public class ExpressionEvaluator implements AutoCloseable {
   }
 
   public ExpressionEvaluator(List<String> listJars) throws IOException, IllegalAccessException, IllegalStateException {
+    this(listJars, null);
+  }
+
+  public ExpressionEvaluator(List<String> listJars, String libName) throws IOException, IllegalAccessException, IllegalStateException {
     String tmp_dir = GazellePluginConfig.getTempFile();
     if (tmp_dir == null) {
       tmp_dir = System.getProperty("java.io.tmpdir");
     }
-    jniWrapper = new ExpressionEvaluatorJniWrapper(tmp_dir, listJars);
+    jniWrapper = new ExpressionEvaluatorJniWrapper(tmp_dir, listJars, libName);
     jniWrapper.nativeSetJavaTmpDir(jniWrapper.tmp_dir_path);
     jniWrapper.nativeSetBatchSize(GazellePluginConfig.getBatchSize());
     jniWrapper.nativeSetMetricsTime(GazellePluginConfig.getEnableMetricsTime());

--- a/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -33,9 +33,9 @@ public class ExpressionEvaluatorJniWrapper {
         public String tmp_dir_path;
 
         /** Wrapper for native API. */
-        public ExpressionEvaluatorJniWrapper(String tmp_dir, List<String> listJars)
+        public ExpressionEvaluatorJniWrapper(String tmp_dir, List<String> listJars, String libName)
                         throws IOException, IllegalAccessException, IllegalStateException {
-                JniUtils jni = JniUtils.getInstance(tmp_dir);
+                JniUtils jni = JniUtils.getInstance(tmp_dir, libName);
                 jni.setTempDir();
                 jni.setJars(listJars);
                 tmp_dir_path = jni.getTempDir();

--- a/jvm/src/main/java/com/intel/oap/vectorized/JniUtils.java
+++ b/jvm/src/main/java/com/intel/oap/vectorized/JniUtils.java
@@ -55,11 +55,15 @@ public class JniUtils {
   }
 
   public static JniUtils getInstance(String tmp_dir) throws IOException {
+    return getInstance(tmp_dir, null);
+  }
+
+  public static JniUtils getInstance(String tmp_dir, String lib_name) throws IOException {
     if (INSTANCE == null) {
       synchronized (JniUtils.class) {
         if (INSTANCE == null) {
           try {
-            INSTANCE = new JniUtils(tmp_dir);
+            INSTANCE = new JniUtils(tmp_dir, lib_name);
           } catch (IllegalAccessException ex) {
             throw new IOException("IllegalAccess", ex);
           }
@@ -70,6 +74,10 @@ public class JniUtils {
   }
 
   private JniUtils(String _tmp_dir) throws IOException, IllegalAccessException, IllegalStateException {
+    this(_tmp_dir, null);
+  }
+
+  private JniUtils(String _tmp_dir, String _lib_name) throws IOException, IllegalAccessException, IllegalStateException {
     if (!isLoaded) {
       if (_tmp_dir.contains("nativesql")) {
         tmp_dir = _tmp_dir;
@@ -79,11 +87,15 @@ public class JniUtils {
         tmp_dir = path.toAbsolutePath().toString();
       }
       try {
-        loadLibraryFromJar(tmp_dir);
+        loadLibraryFromJarWithLib(tmp_dir, _lib_name);
       } catch (IOException ex) {
         System.load(ARROW_LIBRARY_NAME);
         System.load(GANDIVA_LIBRARY_NAME);
-        System.loadLibrary(LIBRARY_NAME);
+        if (_lib_name != null) {
+          System.loadLibrary(_lib_name);
+        } else {
+          System.loadLibrary(LIBRARY_NAME);
+        }
       }
       isLoaded = true;
     }
@@ -110,32 +122,7 @@ public class JniUtils {
   }
 
   static void loadLibraryFromJar(String tmp_dir) throws IOException, IllegalAccessException {
-    synchronized (JniUtils.class) {
-      if (tmp_dir == null) {
-        tmp_dir = System.getProperty("java.io.tmpdir");
-      }
-      final File arrowlibraryFile = moveFileFromJarToTemp(tmp_dir, ARROW_LIBRARY_NAME);
-      Path arrow_target = Paths.get(arrowlibraryFile.getPath());
-      Path arrow_link = Paths.get(tmp_dir, ARROW_PARENT_LIBRARY_NAME);
-      if (Files.exists(arrow_link)) {
-        Files.delete(arrow_link);
-      }
-      Path symLink = Files.createSymbolicLink(arrow_link, arrow_target);
-      System.load(arrowlibraryFile.getAbsolutePath());
-
-      final File gandivalibraryFile = moveFileFromJarToTemp(tmp_dir, GANDIVA_LIBRARY_NAME);
-      Path gandiva_target = Paths.get(gandivalibraryFile.getPath());
-      Path gandiva_link = Paths.get(tmp_dir, GANDIVA_PARENT_LIBRARY_NAME);
-      if (Files.exists(gandiva_link)) {
-        Files.delete(gandiva_link);
-      }
-      Files.createSymbolicLink(gandiva_link, gandiva_target);
-      System.load(gandivalibraryFile.getAbsolutePath());
-
-      final String libraryToLoad = System.mapLibraryName(LIBRARY_NAME);
-      final File libraryFile = moveFileFromJarToTemp(tmp_dir, libraryToLoad);
-      System.load(libraryFile.getAbsolutePath());
-    }
+    loadLibraryFromJarWithLib(tmp_dir, null);
   }
 
   private static void loadLibraryFromJar(String source_jar, String tmp_dir) throws IOException, IllegalAccessException {
@@ -162,6 +149,40 @@ public class JniUtils {
        * Files.list(new File(tmp_dir + "/tmp/").toPath()).forEach(path -> {
        * System.out.println(path); });
        */
+    }
+  }
+
+  static void loadLibraryFromJarWithLib(String tmp_dir, String lib_name) throws IOException, IllegalAccessException {
+    synchronized (JniUtils.class) {
+      if (tmp_dir == null) {
+        tmp_dir = System.getProperty("java.io.tmpdir");
+      }
+      final File arrowlibraryFile = moveFileFromJarToTemp(tmp_dir, ARROW_LIBRARY_NAME);
+      Path arrow_target = Paths.get(arrowlibraryFile.getPath());
+      Path arrow_link = Paths.get(tmp_dir, ARROW_PARENT_LIBRARY_NAME);
+      if (Files.exists(arrow_link)) {
+        Files.delete(arrow_link);
+      }
+      Path symLink = Files.createSymbolicLink(arrow_link, arrow_target);
+      System.load(arrowlibraryFile.getAbsolutePath());
+
+      final File gandivalibraryFile = moveFileFromJarToTemp(tmp_dir, GANDIVA_LIBRARY_NAME);
+      Path gandiva_target = Paths.get(gandivalibraryFile.getPath());
+      Path gandiva_link = Paths.get(tmp_dir, GANDIVA_PARENT_LIBRARY_NAME);
+      if (Files.exists(gandiva_link)) {
+        Files.delete(gandiva_link);
+      }
+      Files.createSymbolicLink(gandiva_link, gandiva_target);
+      System.load(gandivalibraryFile.getAbsolutePath());
+
+      final String libraryToLoad;
+      if (lib_name != null) {
+        libraryToLoad = lib_name;
+      } else {
+        libraryToLoad = System.mapLibraryName(LIBRARY_NAME);
+      }
+      final File libraryFile = moveFileFromJarToTemp(tmp_dir, libraryToLoad);
+      System.load(libraryFile.getAbsolutePath());
     }
   }
 

--- a/jvm/src/main/scala/com/intel/oap/GazellePluginConfig.scala
+++ b/jvm/src/main/scala/com/intel/oap/GazellePluginConfig.scala
@@ -128,6 +128,10 @@ class GazellePluginConfig(conf: SQLConf) extends Logging {
   val enablePreferColumnar: Boolean =
     conf.getConfString("spark.oap.sql.columnar.preferColumnar", "true").toBoolean
 
+  // This config is used for testing. Setting to false will disable loading native libraries.
+  val loadNative: Boolean =
+    conf.getConfString("spark.oap.sql.columnar.loadnative", "true").toBoolean
+
   // fallback to row operators if there are several continous joins
   val joinOptimizationThrottle: Integer =
     conf.getConfString("spark.oap.sql.columnar.joinOptimizationLevel", "12").toInt

--- a/jvm/src/main/scala/com/intel/oap/GazellePluginConfig.scala
+++ b/jvm/src/main/scala/com/intel/oap/GazellePluginConfig.scala
@@ -132,6 +132,10 @@ class GazellePluginConfig(conf: SQLConf) extends Logging {
   val loadNative: Boolean =
     conf.getConfString("spark.oap.sql.columnar.loadnative", "true").toBoolean
 
+  // This config is used for specifying the name of the native library.
+  val nativeLibName: String =
+    conf.getConfString("spark.oap.sql.columnar.libname", "spark_columnar_jni")
+
   // fallback to row operators if there are several continous joins
   val joinOptimizationThrottle: Integer =
     conf.getConfString("spark.oap.sql.columnar.joinOptimizationLevel", "12").toInt

--- a/jvm/src/main/scala/com/intel/oap/execution/WholeStageTransformerExec.scala
+++ b/jvm/src/main/scala/com/intel/oap/execution/WholeStageTransformerExec.scala
@@ -90,6 +90,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
   val numaBindingInfo = GazellePluginConfig.getConf.numaBindingInfo
   val enableColumnarSortMergeJoinLazyRead =
     GazellePluginConfig.getConf.enableColumnarSortMergeJoinLazyRead
+  val libName = GazellePluginConfig.getConf.nativeLibName
 
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),

--- a/jvm/src/main/scala/com/intel/oap/execution/WholestageColumnarRDD.scala
+++ b/jvm/src/main/scala/com/intel/oap/execution/WholestageColumnarRDD.scala
@@ -56,6 +56,7 @@ class WholestageColumnarRDD(
     extends RDD[ColumnarBatch](sc, Nil) {
   val numaBindingInfo = GazellePluginConfig.getConf.numaBindingInfo
   val loadNative = GazellePluginConfig.getConf.loadNative
+  val libName = GazellePluginConfig.getConf.nativeLibName
 
   override protected def getPartitions: Array[Partition] = {
     inputPartitions.zipWithIndex.map {
@@ -117,7 +118,7 @@ class WholestageColumnarRDD(
     var outputSchema : Schema = null
     var resIter : BatchIterator = null
     if (loadNative) {
-      val transKernel = new ExpressionEvaluator(jarList.toList.asJava)
+      val transKernel = new ExpressionEvaluator(jarList.toList.asJava, libName)
       val inBatchIter: ColumnarNativeIterator = null
       inputSchema = ConverterUtils.toArrowSchema(wsCtx.inputAttributes)
       outputSchema = ConverterUtils.toArrowSchema(wsCtx.outputAttributes)

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <arrow.script.dir>${project.basedir}/../tools</arrow.script.dir>
+    <build_cpp>ON</build_cpp>
     <cpp_tests>OFF</cpp_tests>
     <build_arrow>ON</build_arrow>
     <static_arrow>OFF</static_arrow>


### PR DESCRIPTION
This pr:

- added an option for deciding whether to compile CPP

- added a config for the native library name

With this pr, you can disable compiling CPP code by adding "**-Dbuild_cpp=OFF**" to your mvn compiling command.
When running queries, please use below two configs:

// Setting to false will disable loading native libraries.
--conf spark.oap.sql.columnar.loadnative=false

// Config the name of the native library to load.
--conf spark.oap.sql.columnar.libname="xxx"

Closes https://github.com/oap-project/gazelle-jni/issues/23.