### PR TITLE
[GJ-23] Fix the incorrect library name

### DIFF
--- a/jvm/src/main/java/com/intel/oap/vectorized/JniUtils.java
+++ b/jvm/src/main/java/com/intel/oap/vectorized/JniUtils.java
@@ -177,7 +177,7 @@ public class JniUtils {
 
       final String libraryToLoad;
       if (lib_name != null) {
-        libraryToLoad = lib_name;
+        libraryToLoad = System.mapLibraryName(lib_name);
       } else {
         libraryToLoad = System.mapLibraryName(LIBRARY_NAME);
       }


### PR DESCRIPTION
This pr fixed the incorrect library name.
https://github.com/oap-project/gazelle-jni/issues/23