### PR TITLE
[GJ-41] Support WS Tansformer with row-based output

### DIFF
--- a/jvm/src/main/java/com/intel/oap/row/JniInstance.java
+++ b/jvm/src/main/java/com/intel/oap/row/JniInstance.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.row;
+
+import io.kyligence.jni.engine.LocalEngine;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Java API for in-process profiling. Serves as a wrapper around
+ * async-profiler native library. This class is a singleton.
+ * The first call to {@link #getInstance()} initiates loading of
+ * libasyncProfiler.so.
+ */
+public class JniInstance {
+
+    private static JniInstance instance;
+
+    private String currLibPath = "";
+
+    private JniInstance() {
+    }
+
+    public static JniInstance getInstance() {
+        return getInstance(null);
+    }
+
+    public static synchronized JniInstance getInstance(String libPath) {
+        if (instance != null) {
+            return instance;
+        }
+
+        File file = null;
+        boolean libPathExists = false;
+        if (StringUtils.isNotBlank(libPath)) {
+            file = new File(libPath);
+            libPathExists = file.isFile() && file.exists();
+        }
+        if (!libPathExists) {
+            String soFileName = "/liblocal_engine_jnid.so";
+            try {
+                InputStream is = JniInstance.class.getResourceAsStream(soFileName);
+                file = File.createTempFile("lib", ".so");
+                OutputStream os = new FileOutputStream(file);
+                byte[] buffer = new byte[128 << 10];
+                int length;
+                while ((length = is.read(buffer)) != -1) {
+                    os.write(buffer, 0, length);
+                }
+                is.close();
+                os.close();
+            } catch (IOException e) {
+            }
+        }
+        if (file != null) {
+            try {
+                file.setReadable(true, false);
+                System.load(file.getAbsolutePath());
+                libPath = file.getAbsolutePath();
+            } catch (UnsatisfiedLinkError error) {
+                throw error;
+            }
+        }
+        instance = new JniInstance();
+        instance.setCurrLibPath(libPath);
+        LocalEngine.initEngineEnv();
+        return instance;
+    }
+
+    public void setCurrLibPath(String currLibPath) {
+        this.currLibPath = currLibPath;
+    }
+
+    public LocalEngine buildLocalEngine(byte[] substraitPlan) {
+        LocalEngine localEngine = new LocalEngine(substraitPlan);
+        return localEngine;
+    }
+}

--- a/jvm/src/main/java/com/intel/oap/row/RowIterator.java
+++ b/jvm/src/main/java/com/intel/oap/row/RowIterator.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.row;
+
+import io.kyligence.jni.engine.LocalEngine;
+
+import java.io.IOException;
+
+public class RowIterator {
+
+  private LocalEngine localEngine;
+  private boolean closed = false;
+
+  public RowIterator() throws IOException {}
+
+  public RowIterator(byte[] plan, String soFilePath) throws IOException {
+    this.localEngine = JniInstance.getInstance(soFilePath).buildLocalEngine(plan);
+    this.localEngine.execute();
+  }
+
+  public boolean hasNext() throws IOException {
+    return this.localEngine.hasNext();
+  }
+
+  public SparkRowInfo next() throws IOException {
+    if (this.localEngine == null) {
+      return null;
+    }
+    return this.localEngine.next();
+  }
+
+  public void close() {
+    if (!closed) {
+      if (this.localEngine != null) {
+        try {
+          this.localEngine.close();
+        } catch (IOException e) {
+        }
+      }
+      closed = true;
+    }
+  }
+}

--- a/jvm/src/main/java/com/intel/oap/row/SparkRowInfo.java
+++ b/jvm/src/main/java/com/intel/oap/row/SparkRowInfo.java
@@ -15,23 +15,18 @@
  * limitations under the License.
  */
 
-package com.intel.oap.vectorized;
+package com.intel.oap.row;
 
-/** POJO to hold the output file path of the designated partition id */
-public class PartitionFileInfo {
-  private final int partitionId;
-  private final String filePath;
+public class SparkRowInfo {
+    public long[] offsets;
+    public long[] lengths;
+    public long memoryAddress;
+    public long fieldsNum;
 
-  public PartitionFileInfo(int partitionId, String filePath) {
-    this.partitionId = partitionId;
-    this.filePath = filePath;
-  }
-
-  public int getPartitionId() {
-    return partitionId;
-  }
-
-  public String getFilePath() {
-    return filePath;
-  }
+    public SparkRowInfo(long[] offsets, long[] lengths, long memoryAddress, long fieldsNum) {
+        this.offsets = offsets;
+        this.lengths = lengths;
+        this.memoryAddress = memoryAddress;
+        this.fieldsNum = fieldsNum;
+    }
 }

--- a/jvm/src/main/java/io/kyligence/jni/engine/LocalEngine.java
+++ b/jvm/src/main/java/io/kyligence/jni/engine/LocalEngine.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kyligence.jni.engine;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import com.intel.oap.row.SparkRowInfo;
+
+public class LocalEngine implements Closeable {
+    public static native long test(int a, int b);
+
+    public static native void initEngineEnv();
+
+    private long nativeExecutor;
+    private byte[] plan;
+
+    public LocalEngine(byte[] plan) {
+        this.plan = plan;
+    }
+
+    public native void execute();
+
+    public native boolean hasNext();
+
+    public native SparkRowInfo next();
+
+
+    @Override
+    public native void close() throws IOException;
+}

--- a/jvm/src/main/scala/com/intel/oap/GazellePluginConfig.scala
+++ b/jvm/src/main/scala/com/intel/oap/GazellePluginConfig.scala
@@ -17,7 +17,6 @@
 
 package com.intel.oap
 
-import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.SQLConf
 
@@ -128,6 +127,10 @@ class GazellePluginConfig(conf: SQLConf) extends Logging {
   val enablePreferColumnar: Boolean =
     conf.getConfString("spark.oap.sql.columnar.preferColumnar", "true").toBoolean
 
+  // This config is used for specifying whether to use columnar basic iterator.
+  val enableColumnarIterator: Boolean =
+    conf.getConfString("spark.oap.sql.columnar.iterator", "true").toBoolean
+
   // This config is used for testing. Setting to false will disable loading native libraries.
   val loadNative: Boolean =
     conf.getConfString("spark.oap.sql.columnar.loadnative", "true").toBoolean
@@ -135,6 +138,10 @@ class GazellePluginConfig(conf: SQLConf) extends Logging {
   // This config is used for specifying the name of the native library.
   val nativeLibName: String =
     conf.getConfString("spark.oap.sql.columnar.libname", "spark_columnar_jni")
+
+  // This config is used for specifying the absolute path of the native library.
+  val nativeLibPath: String =
+    conf.getConfString("spark.oap.sql.columnar.libpath", "")
 
   // fallback to row operators if there are several continous joins
   val joinOptimizationThrottle: Integer =

--- a/jvm/src/main/scala/com/intel/oap/execution/BasicPhysicalOperatorTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/execution/BasicPhysicalOperatorTransformer.scala
@@ -21,8 +21,9 @@ import com.intel.oap.expression._
 import com.intel.oap.substrait.expression.ExpressionNode
 import com.intel.oap.substrait.rel.{RelBuilder, RelNode}
 import com.intel.oap.substrait.SubstraitContext
-
+import com.intel.oap.GazellePluginConfig
 import org.apache.spark.SparkConf
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -43,7 +44,7 @@ case class ConditionProjectExecTransformer(
 
   val sparkConf: SparkConf = sparkContext.getConf
 
-  override def supportsColumnar: Boolean = true
+  override def supportsColumnar: Boolean = GazellePluginConfig.getConf.enableColumnarIterator
 
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),

--- a/jvm/src/main/scala/com/intel/oap/execution/NativeWholestageRowRDD.scala
+++ b/jvm/src/main/scala/com/intel/oap/execution/NativeWholestageRowRDD.scala
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.execution
+
+import java.io._
+
+import com.intel.oap.GazellePluginConfig
+import com.intel.oap.row.RowIterator
+import org.apache.spark.{Partition, SparkContext, SparkException, TaskContext}
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory}
+import org.apache.spark.util._
+
+class WholestageNativeRowRDD(
+    sc: SparkContext,
+    @transient private val inputPartitions: Seq[InputPartition],
+    partitionReaderFactory: PartitionReaderFactory,
+    columnarReads: Boolean)
+    extends RDD[InternalRow](sc, Nil) {
+  val numaBindingInfo = GazellePluginConfig.getConf.numaBindingInfo
+  val loadNative = GazellePluginConfig.getConf.loadNative
+  val libName = GazellePluginConfig.getConf.nativeLibName
+
+  override protected def getPartitions: Array[Partition] = {
+    inputPartitions.zipWithIndex.map {
+      case (inputPartition, index) => new NativeSubstraitPartition(index, inputPartition)
+    }.toArray
+  }
+
+  private def castPartition(split: Partition): NativeSubstraitPartition = split match {
+    case p: NativeSubstraitPartition => p
+    case _ => throw new SparkException(s"[BUG] Not a NativeSubstraitPartition: $split")
+  }
+
+  private def castNativePartition(split: Partition): NativeFilePartition = split match {
+    case NativeSubstraitPartition(_, p: NativeFilePartition) => p
+    case _ => throw new SparkException(s"[BUG] Not a NativeSubstraitPartition: $split")
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
+    ExecutorManager.tryTaskSet(numaBindingInfo)
+
+    val inputPartition = castNativePartition(split)
+
+    var resIter : RowIterator = null
+    if (loadNative) {
+      resIter = new RowIterator(inputPartition.substraitPlan,
+        GazellePluginConfig.getConf.nativeLibPath)
+    }
+
+    val iter = new Iterator[InternalRow] with AutoCloseable {
+      private val inputMetrics = TaskContext.get().taskMetrics().inputMetrics
+      private[this] var currentIterator: Iterator[InternalRow] = null
+      private var totalBatch = 0
+
+      override def hasNext: Boolean = {
+        if (loadNative) {
+          val hasNextRes = (currentIterator != null && currentIterator.hasNext) || nextIterator()
+          hasNextRes
+        } else {
+          false
+        }
+      }
+
+      private def nextIterator(): Boolean = {
+        var startTime = System.nanoTime()
+        if (resIter.hasNext) {
+          logWarning(s"===========${totalBatch} ${System.nanoTime() - startTime}")
+          startTime = System.nanoTime()
+          val sparkRowInfo = resIter.next()
+          totalBatch += 1
+          logWarning(s"===========${totalBatch} ${System.nanoTime() - startTime}")
+          val result = if (sparkRowInfo.offsets != null && sparkRowInfo.offsets.length > 0) {
+            val numRows = sparkRowInfo.offsets.length
+            val numFields = sparkRowInfo.fieldsNum
+            currentIterator = new Iterator[InternalRow] with AutoCloseable {
+
+              var rowId = 0
+              val row = new UnsafeRow(numFields.intValue())
+
+              override def hasNext: Boolean = {
+                rowId < numRows
+              }
+
+              override def next(): InternalRow = {
+                if (rowId >= numRows) throw new NoSuchElementException
+                val (offset, length) = (sparkRowInfo.offsets(rowId), sparkRowInfo.lengths(rowId))
+                row.pointTo(null, sparkRowInfo.memoryAddress + offset, length.toInt)
+                rowId += 1
+                row
+              }
+
+              override def close(): Unit = {}
+            }
+            true
+          } else {
+            false
+          }
+          result
+        } else {
+          false
+        }
+      }
+
+      override def next(): InternalRow = {
+        if (!hasNext) {
+          throw new java.util.NoSuchElementException("End of stream")
+        }
+        val cb = currentIterator.next()
+        cb
+      }
+
+      override def close(): Unit = {
+        resIter.close()
+      }
+    }
+    iter
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = {
+    castPartition(split).inputPartition.preferredLocations()
+  }
+
+}

--- a/jvm/src/test/scala/com/intel/oap/benchmarks/BenchmarkTest.scala
+++ b/jvm/src/test/scala/com/intel/oap/benchmarks/BenchmarkTest.scala
@@ -36,7 +36,7 @@ object BenchmarkTest {
       val resourcePath = rootPath + "../../../src/test/resources/"
       val dataPath = resourcePath + "/tpch-data/"
       val queryPath = resourcePath + "/queries/"
-      (new File(dataPath).getAbsolutePath, "parquet", 1, false, queryPath + "q06.sql", "")
+      (new File(dataPath).getAbsolutePath, "parquet", 10, false, queryPath + "q06.sql", "")
     }
 
     val sqlStr = Source.fromFile(new File(sqlFilePath), "UTF-8")
@@ -68,7 +68,10 @@ object BenchmarkTest {
         .config("spark.sql.execution.arrow.maxRecordsPerBatch", "20000")
         .config("spark.oap.sql.columnar.columnartorow", "false")
         .config("spark.oap.sql.columnar.loadnative", "false")
-        .config("spark.sql.planChangeLog.level", "info")
+        .config("spark.oap.sql.columnar.libpath",
+          "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse/cmake-build-release/utils/local-engine/liblocal_engine_jni.so")
+        .config("spark.oap.sql.columnar.iterator", "true")
+        //.config("spark.sql.planChangeLog.level", "info")
         .config("spark.sql.columnVector.offheap.enabled", "true")
         .config("spark.memory.offHeap.enabled", "true")
         .config("spark.memory.offHeap.size", "6442450944")
@@ -105,6 +108,7 @@ object BenchmarkTest {
       val startTime = System.nanoTime()
       spark.sql(sql).show(200, false)
       val tookTime = (System.nanoTime() - startTime) / 1000000
+      println(s"Execute ${i} time, time: ${tookTime}")
       tookTimeArr += tookTime
     }
 


### PR DESCRIPTION
1. Support ClickHouse as native engine;
2. Support Row iterator;
3. Add config 'spark.oap.sql.columnar.iterator' to specify whether to use columnar basic iterator

Following PR:
1. JNI Interface
2. Optimise Code 

Closes https://github.com/oap-project/gazelle-jni/issues/41.