### PR TITLE
[GJ-69] Update Velox

### DIFF
--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -51,6 +51,7 @@ set(VELOX_DWIO_DWRF_READER_LIB_PATH "${VELOX_BUILD_PATH}/dwio/dwrf/reader/libvel
 set(VELOX_EXTERNAL_DUCKDB_LIB_PATH "${VELOX_BUILD_PATH}/external/duckdb/libduckdb.a")
 set(VELOX_DUCKDB_PARSER_LIB_PATH "${VELOX_BUILD_PATH}/duckdb/conversion/libvelox_duckdb_parser.a")
 set(VELOX_DUCKDB_CONVERSION_LIB_PATH "${VELOX_BUILD_PATH}/duckdb/conversion/libvelox_duckdb_conversion.a")
+set(VELOX_FUNCTIONS_PRESTOSQL_TYPES_LIB_PATH "${VELOX_BUILD_PATH}/functions/prestosql/types/libvelox_presto_types.a")
 set(VELOX_FUNCTIONS_PRESTOSQL_LIB_PATH "${VELOX_BUILD_PATH}/functions/prestosql/registration/libvelox_functions_prestosql.a")
 set(VELOX_FUNCTIONS_PRESTOSQL_IMPL_LIB_PATH "${VELOX_BUILD_PATH}/functions/prestosql/libvelox_functions_prestosql_impl.a")
 set(VELOX_FUNCTIONS_PRESTOSQL_JSON_LIB_PATH "${VELOX_BUILD_PATH}/functions/prestosql/json/libvelox_functions_json.a")
@@ -573,6 +574,7 @@ macro(build_velox_exec)
   add_library(facebook::velox::duckdb::parser STATIC IMPORTED)
   add_library(facebook::velox::duckdb::conversion STATIC IMPORTED)
   add_library(facebook::velox::functions::prestosql STATIC IMPORTED)
+  add_library(facebook::velox::functions::prestosql::types STATIC IMPORTED)
   add_library(facebook::velox::functions::prestosql::impl STATIC IMPORTED)
   add_library(facebook::velox::functions::json STATIC IMPORTED)
   add_library(facebook::velox::functions::hyperloglog STATIC IMPORTED)
@@ -728,6 +730,10 @@ macro(build_velox_exec)
                         PROPERTIES IMPORTED_LOCATION "${VELOX_FUNCTIONS_PRESTOSQL_LIB_PATH}"
                                    INTERFACE_INCLUDE_DIRECTORIES
                                    "${BINARY_RELEASE_DIR}/include")
+  set_target_properties(facebook::velox::functions::prestosql::types
+                        PROPERTIES IMPORTED_LOCATION "${VELOX_FUNCTIONS_PRESTOSQL_TYPES_LIB_PATH}"
+                                   INTERFACE_INCLUDE_DIRECTORIES
+                                   "${BINARY_RELEASE_DIR}/include")
   set_target_properties(facebook::velox::functions::prestosql::impl
                         PROPERTIES IMPORTED_LOCATION "${VELOX_FUNCTIONS_PRESTOSQL_IMPL_LIB_PATH}"
                                    INTERFACE_INCLUDE_DIRECTORIES
@@ -812,6 +818,7 @@ macro(build_velox_exec)
                     LINK_PUBLIC facebook::velox::type::tz
                     LINK_PUBLIC facebook::velox::external::md5
                     LINK_PUBLIC facebook::velox::buffer
+                    LINK_PUBLIC facebook::velox::functions::prestosql::types
                     LINK_PUBLIC gtest
                     LINK_PUBLIC folly
                     LINK_PUBLIC iberty

--- a/cpp/src/operators/c2r/velox_to_row_converter.cc
+++ b/cpp/src/operators/c2r/velox_to_row_converter.cc
@@ -105,7 +105,6 @@ void VeloxToRowConverter::ResumeVeloxVector() {
         .offset = 0,
         .n_buffers = 2,
         .n_children = 0,
-        .string_data_size = 0,
         .buffers = buffers,
         .children = nullptr,
         .dictionary = nullptr,

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -34,9 +34,9 @@ set(SYSTEM_LOCAL_LIB64_PATH "/usr/local/lib64" CACHE PATH "System Local Lib64 di
 
 Secondly, when compiling Velox, please note that Velox generated static libraries should also be compiled as position independent code.
 Also, some OBJECT settings in CMakeLists are removed in order to acquire the static libraries.
-For these two changes, please refer to this commit [Velox Compiling](https://github.com/rui-mo/velox/commit/ce1dee8f776bc3afa36cd3fc033161fc062cbe98).
+For these two changes, please refer to this branch [Velox_Branch](https://github.com/rui-mo/velox/tree/dev_on_main).
 
-Currently, we depends on this Velox commmit: **8d3e951 (Jan 18 2022)**
+Currently, we depends on this Velox commmit: **0f1983 (Feb 25 2022)**
 
 ### An example for Velox computing in Spark based on Gazelle-Jni
 


### PR DESCRIPTION
This pr updated the dependent Velox version into the latest available commit.

Closes https://github.com/oap-project/gazelle-jni/issues/69.
