### PR TITLE
[GJ-75] Unify function names

### DIFF
--- a/cpp/src/compute/protobuf_utils.cc
+++ b/cpp/src/compute/protobuf_utils.cc
@@ -21,6 +21,10 @@
 #include <google/protobuf/util/type_resolver.h>
 #include <google/protobuf/util/type_resolver_util.h>
 
+#include <fstream>
+#include <iostream>
+#include <string>
+
 using gandiva::ConditionPtr;
 using gandiva::DataTypePtr;
 using gandiva::ExpressionPtr;
@@ -462,4 +466,18 @@ arrow::Result<std::string> SubstraitToJSON(arrow::util::string_view type_name,
     return Status::Invalid("BinaryToJsonStream returned ", status);
   }
   return out;
+}
+
+void MessageToJSONFile(const google::protobuf::Message& message,
+                       const std::string& file_path) {
+  google::protobuf::util::JsonPrintOptions options;
+  options.add_whitespace = true;
+  options.always_print_primitive_fields = true;
+  options.preserve_proto_field_names = true;
+  std::string json_string;
+  google::protobuf::util::MessageToJsonString(message, &json_string, options);
+  std::cin >> json_string;
+  std::ofstream out(file_path);
+  out << json_string;
+  out.close();
 }

--- a/cpp/src/compute/protobuf_utils.h
+++ b/cpp/src/compute/protobuf_utils.h
@@ -72,3 +72,6 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> SubstraitFromJSON(
     arrow::util::string_view type_name, arrow::util::string_view json);
 arrow::Result<std::string> SubstraitToJSON(arrow::util::string_view type_name,
                                            const arrow::Buffer& buf);
+// Write a Protobuf message into a specified file with JSON format.
+void MessageToJSONFile(const google::protobuf::Message& message,
+                       const std::string& file_path);

--- a/cpp/src/jni/jni_common.h
+++ b/cpp/src/jni/jni_common.h
@@ -355,6 +355,7 @@ arrow::Status ParseSubstraitPlan(
     env->ReleaseByteArrayElements(exprs_arr, exprs_bytes, JNI_ABORT);
     return arrow::Status::UnknownError("Unable to parse");
   }
+  // MessageToJSONFile(ws_plan, "/tmp/sub.json");
   auto parser = std::make_shared<gazellejni::compute::SubstraitParser>();
   parser->ParsePlan(ws_plan);
   *out_iter = parser->getResIter();

--- a/jvm/src/main/scala/com/intel/oap/expression/AggregateFunctionsBuilder.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/AggregateFunctionsBuilder.scala
@@ -28,7 +28,7 @@ object AggregateFunctionsBuilder {
     aggregateFunc match {
       case sum: Sum =>
         val functionName = ConverterUtils.makeFuncName(
-          "sum", Seq(sum.child.dataType), FunctionConfig.OPT)
+          ConverterUtils.SUM, Seq(sum.child.dataType), FunctionConfig.OPT)
         ExpressionBuilder.newScalarFunction(functionMap, functionName)
       case other =>
         throw new UnsupportedOperationException(s"not currently supported: $other.")

--- a/jvm/src/main/scala/com/intel/oap/expression/AggregateFunctionsBuilder.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/AggregateFunctionsBuilder.scala
@@ -17,8 +17,8 @@
 
 package com.intel.oap.expression
 
+import com.intel.oap.expression.ConverterUtils.FunctionConfig
 import com.intel.oap.substrait.expression.ExpressionBuilder
-
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 
 object AggregateFunctionsBuilder {
@@ -26,10 +26,11 @@ object AggregateFunctionsBuilder {
   def create(args: java.lang.Object, aggregateFunc: AggregateFunction): Long = {
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     aggregateFunc match {
-      case sum: Sum => {
-        ExpressionBuilder.newScalarFunction(functionMap, "SUM")
-      }
-      case other => null
+      case sum: Sum =>
+        val functionName = ConverterUtils.makeFuncName(
+          "sum", Seq(sum.child.dataType), FunctionConfig.OPT)
+        ExpressionBuilder.newScalarFunction(functionMap, functionName)
+      case other =>
         throw new UnsupportedOperationException(s"not currently supported: $other.")
     }
   }

--- a/jvm/src/main/scala/com/intel/oap/expression/ArithmeticTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/ArithmeticTransformer.scala
@@ -59,7 +59,7 @@ class MultiplyTransformer(left: Expression, right: Expression, original: Express
 
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionName = ConverterUtils.makeFuncName(
-      "multiply", Seq(left.dataType, right.dataType), FunctionConfig.OPT)
+      ConverterUtils.MULTIPLY, Seq(left.dataType, right.dataType), FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],

--- a/jvm/src/main/scala/com/intel/oap/expression/BinaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/BinaryOperatorTransformer.scala
@@ -41,7 +41,8 @@ class AndTransformer(left: Expression, right: Expression, original: Expression)
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "AND")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("and", Seq(left.dataType, right.dataType)))
 
     val expressionNodes = new java.util.ArrayList[ExpressionNode]()
     expressionNodes.add(left_node.asInstanceOf[ExpressionNode])
@@ -66,7 +67,8 @@ class OrTransformer(left: Expression, right: Expression, original: Expression)
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "OR")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("or", Seq(left.dataType, right.dataType)))
 
     val expressionNodes = new java.util.ArrayList[ExpressionNode]()
     expressionNodes.add(left_node.asInstanceOf[ExpressionNode])
@@ -105,7 +107,8 @@ class LikeTransformer(left: Expression, right: Expression, original: Expression)
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "LIKE")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("like", Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -137,7 +140,8 @@ class EqualToTransformer(left: Expression, right: Expression, original: Expressi
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "EQUAL_TO")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("equal", Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -169,7 +173,8 @@ class LessThanTransformer(left: Expression, right: Expression, original: Express
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "LESS_THAN")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("lt", Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -194,7 +199,8 @@ class LessThanOrEqualTransformer(left: Expression, right: Expression, original: 
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "LESS_THAN_OR_EQUAL")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("lte", Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -219,7 +225,8 @@ class GreaterThanTransformer(left: Expression, right: Expression, original: Expr
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "GREATER_THAN")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("gt", Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -244,7 +251,8 @@ class GreaterThanOrEqualTransformer(left: Expression, right: Expression, origina
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "GREATER_THAN_OR_EQUAL")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("gte", Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],

--- a/jvm/src/main/scala/com/intel/oap/expression/BinaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/BinaryOperatorTransformer.scala
@@ -42,7 +42,7 @@ class AndTransformer(left: Expression, right: Expression, original: Expression)
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("and", Seq(left.dataType, right.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.AND, Seq(left.dataType, right.dataType)))
 
     val expressionNodes = new java.util.ArrayList[ExpressionNode]()
     expressionNodes.add(left_node.asInstanceOf[ExpressionNode])
@@ -68,7 +68,7 @@ class OrTransformer(left: Expression, right: Expression, original: Expression)
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("or", Seq(left.dataType, right.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.OR, Seq(left.dataType, right.dataType)))
 
     val expressionNodes = new java.util.ArrayList[ExpressionNode]()
     expressionNodes.add(left_node.asInstanceOf[ExpressionNode])
@@ -108,7 +108,7 @@ class LikeTransformer(left: Expression, right: Expression, original: Expression)
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("like", Seq(left.dataType, right.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.LIKE, Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -141,7 +141,7 @@ class EqualToTransformer(left: Expression, right: Expression, original: Expressi
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("equal", Seq(left.dataType, right.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.EQUAL, Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -174,7 +174,7 @@ class LessThanTransformer(left: Expression, right: Expression, original: Express
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("lt", Seq(left.dataType, right.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.LESS_THAN, Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -199,8 +199,8 @@ class LessThanOrEqualTransformer(left: Expression, right: Expression, original: 
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("lte", Seq(left.dataType, right.dataType)))
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, ConverterUtils.makeFuncName(
+        ConverterUtils.LESS_THAN_OR_EQUAL, Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -226,7 +226,7 @@ class GreaterThanTransformer(left: Expression, right: Expression, original: Expr
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("gt", Seq(left.dataType, right.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.GREATER_THAN, Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],
@@ -251,8 +251,8 @@ class GreaterThanOrEqualTransformer(left: Expression, right: Expression, origina
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("gte", Seq(left.dataType, right.dataType)))
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, ConverterUtils.makeFuncName(
+        ConverterUtils.GREATER_THAN_OR_EQUAL, Seq(left.dataType, right.dataType)))
 
     val expressNodes = Lists.newArrayList(
       left_node.asInstanceOf[ExpressionNode],

--- a/jvm/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -398,54 +398,6 @@ object ConverterUtils extends Logging {
     }
   }
 
-  object FunctionConfig extends Enumeration {
-    type Config = Value
-    val REQ, OPT, NON = Value
-  }
-
-  // This method is used to create a function name with input types.
-  // The format would be aligned with that specified in Substrait.
-  // The function name Format:
-  // <function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>
-  def makeFuncName(funcName: String, datatypes: Seq[DataType],
-                   config: FunctionConfig.Config = FunctionConfig.NON): String = {
-    var typedFuncName = config match {
-      case FunctionConfig.REQ =>
-        funcName.concat(":req_")
-      case FunctionConfig.OPT =>
-        funcName.concat(":opt_")
-      case FunctionConfig.NON =>
-        funcName.concat(":")
-      case other =>
-        throw new UnsupportedOperationException(s"$other is not supported.")
-    }
-    for (idx <- datatypes.indices) {
-      val datatype = datatypes(idx)
-      typedFuncName = datatype match {
-        case BooleanType =>
-          // TODO: Not in Substrait yet.
-          typedFuncName.concat("bool")
-        case IntegerType =>
-          typedFuncName.concat("i32")
-        case LongType =>
-          typedFuncName.concat("i64")
-        case DoubleType =>
-          typedFuncName.concat("fp64")
-        case DateType =>
-          typedFuncName.concat("date")
-        case StringType =>
-          typedFuncName.concat("str")
-        case other =>
-          throw new UnsupportedOperationException(s"Type $other not supported.")
-      }
-      // For the last item, do not need to add _.
-      if (idx < (datatypes.size - 1)) {
-        typedFuncName = typedFuncName.concat("_")
-      }
-    }
-    typedFuncName
-  }
-
   def getTypeNodeFromAttributes(attributes: Seq[Attribute]): java.util.ArrayList[TypeNode] = {
     val typeNodes = new java.util.ArrayList[TypeNode]()
     for (attr <- attributes) {
@@ -699,4 +651,69 @@ object ConverterUtils extends Logging {
       ("1000000000000000000000000000000000000", 37, 0))
     POWERS_OF_10(pow)
   }
+
+  // This method is used to specify the function arg.
+  object FunctionConfig extends Enumeration {
+    type Config = Value
+    val REQ, OPT, NON = Value
+  }
+
+  // This method is used to create a function name with input types.
+  // The format would be aligned with that specified in Substrait.
+  // The function name Format:
+  // <function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>
+  def makeFuncName(funcName: String, datatypes: Seq[DataType],
+                   config: FunctionConfig.Config = FunctionConfig.NON): String = {
+    var typedFuncName = config match {
+      case FunctionConfig.REQ =>
+        funcName.concat(":req_")
+      case FunctionConfig.OPT =>
+        funcName.concat(":opt_")
+      case FunctionConfig.NON =>
+        funcName.concat(":")
+      case other =>
+        throw new UnsupportedOperationException(s"$other is not supported.")
+    }
+    for (idx <- datatypes.indices) {
+      val datatype = datatypes(idx)
+      typedFuncName = datatype match {
+        case BooleanType =>
+          // TODO: Not in Substrait yet.
+          typedFuncName.concat("bool")
+        case IntegerType =>
+          typedFuncName.concat("i32")
+        case LongType =>
+          typedFuncName.concat("i64")
+        case DoubleType =>
+          typedFuncName.concat("fp64")
+        case DateType =>
+          typedFuncName.concat("date")
+        case StringType =>
+          typedFuncName.concat("str")
+        case other =>
+          throw new UnsupportedOperationException(s"Type $other not supported.")
+      }
+      // For the last item, do not need to add _.
+      if (idx < (datatypes.size - 1)) {
+        typedFuncName = typedFuncName.concat("_")
+      }
+    }
+    typedFuncName
+  }
+
+  // Function names used by Substrait plan.
+  final val SUM = "sum"
+  final val MULTIPLY = "multiply"
+  final val AND = "and"
+  final val OR = "or"
+  final val LIKE = "like"
+  final val EQUAL = "equal"
+  final val LESS_THAN = "lt"
+  final val LESS_THAN_OR_EQUAL = "lte"
+  final val GREATER_THAN = "gt"
+  final val GREATER_THAN_OR_EQUAL = "gte"
+  final val ALIAS = "alias"
+  final val IS_NOT_NULL = "is_not_null"
+  final val IS_NULL = "is_null"
+  final val CAST = "cast"
 }

--- a/jvm/src/main/scala/com/intel/oap/expression/NamedExpressionsTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/NamedExpressionsTransformer.scala
@@ -38,7 +38,7 @@ class AliasTransformer(child: Expression, name: String)(
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("alias", Seq(child.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.ALIAS, Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(child.dataType, child.nullable)
 

--- a/jvm/src/main/scala/com/intel/oap/expression/NamedExpressionsTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/NamedExpressionsTransformer.scala
@@ -37,7 +37,8 @@ class AliasTransformer(child: Expression, name: String)(
       throw new UnsupportedOperationException(s"not supported yet")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "ALIAS")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("alias", Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(child.dataType, child.nullable)
 

--- a/jvm/src/main/scala/com/intel/oap/expression/UnaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/UnaryOperatorTransformer.scala
@@ -44,7 +44,7 @@ class IsNotNullTransformer(child: Expression, original: Expression)
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("is_not_null", Seq(child.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.IS_NOT_NULL, Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuiler.makeBoolean(true)
     ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
@@ -63,7 +63,7 @@ class IsNullTransformer(child: Expression, original: Expression)
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("is_null", Seq(child.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.IS_NULL, Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuiler.makeBoolean(true)
     ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
@@ -144,7 +144,7 @@ class CastTransformer(
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName("cast", Seq(child.dataType)))
+      ConverterUtils.makeFuncName(ConverterUtils.CAST, Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(dataType, nullable = true)
 

--- a/jvm/src/main/scala/com/intel/oap/expression/UnaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/UnaryOperatorTransformer.scala
@@ -43,7 +43,8 @@ class IsNotNullTransformer(child: Expression, original: Expression)
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "IS_NOT_NULL")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("is_not_null", Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuiler.makeBoolean(true)
     ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
@@ -61,8 +62,8 @@ class IsNullTransformer(child: Expression, original: Expression)
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "IS_NULL")
-
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("is_null", Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuiler.makeBoolean(true)
     ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
@@ -142,7 +143,8 @@ class CastTransformer(
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap, "CAST")
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+      ConverterUtils.makeFuncName("cast", Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(dataType, nullable = true)
 


### PR DESCRIPTION
This pr unified the function names according to the Substrait specifications in:
https://substrait.io/extensions/.

Based on: https://github.com/substrait-io/substrait/pull/147.
Closes https://github.com/oap-project/gazelle-jni/issues/75.

