### PR TITLE
[GJ-77] Make execution backend pluggable

### DIFF
--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -1,42 +1,40 @@
 #!/usr/bin/env bash
 
 set -eu
+set -x
 
 BUILD_CPP=${1:-ON}
-TESTS=${2:-OFF}
+BUILD_TESTS=${2:-OFF}
 BUILD_ARROW=${3:-ON}
 STATIC_ARROW=${4:-OFF}
 BUILD_PROTOBUF=${5:-ON}
 ARROW_ROOT=${6:-/usr/local}
 ARROW_BFS_INSTALL_DIR=${7}
 BUILD_JEMALLOC=${8:-ON}
+BUILD_GAZELLE_CPP=${9:-OFF}
 
-echo "CMAKE Arguments:"
-echo "BUILD_CPP=${BUILD_CPP}"
-echo "TESTS=${TESTS}"
-echo "BUILD_ARROW=${BUILD_ARROW}"
-echo "STATIC_ARROW=${STATIC_ARROW}"
-echo "BUILD_PROTOBUF=${BUILD_PROTOBUF}"
-echo "ARROW_ROOT=${ARROW_ROOT}"
-echo "ARROW_BUILD_FROM_SOURCE_INSTALL_DIR=${ARROW_BFS_INSTALL_DIR}"
-echo "BUILD_JEMALLOC=${BUILD_JEMALLOC}"
+if [ "$BUILD_CPP" == "ON" ]; then
+  NPROC=$(nproc --ignore=2)
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
-echo $CURRENT_DIR
-cd ${CURRENT_DIR}
-if [ -d build ]; then
+  CURRENT_DIR=$(
+    cd "$(dirname "$BASH_SOURCE")"
+    pwd
+  )
+  cd "${CURRENT_DIR}"
+
+  if [ -d build ]; then
     rm -r build
-fi
-
-if [ $BUILD_CPP == "ON" ]; then
-mkdir build
-cd build
-cmake .. -DTESTS=${TESTS} -DBUILD_ARROW=${BUILD_ARROW} -DSTATIC_ARROW=${STATIC_ARROW} -DBUILD_PROTOBUF=${BUILD_PROTOBUF} -DARROW_ROOT=${ARROW_ROOT} -DARROW_BFS_INSTALL_DIR=${ARROW_BFS_INSTALL_DIR} -DBUILD_JEMALLOC=${BUILD_JEMALLOC}
-make -j2
-
-set +eu
-
-make -j2
-
-set +eu
+  fi
+  mkdir build
+  cd build
+  cmake .. \
+    -DBUILD_TESTS=${BUILD_TESTS} \
+    -DBUILD_ARROW=${BUILD_ARROW} \
+    -DSTATIC_ARROW=${STATIC_ARROW} \
+    -DBUILD_PROTOBUF=${BUILD_PROTOBUF} \
+    -DARROW_ROOT=${ARROW_ROOT} \
+    -DARROW_BFS_INSTALL_DIR=${ARROW_BFS_INSTALL_DIR} \
+    -DBUILD_JEMALLOC=${BUILD_JEMALLOC} \
+    -DBUILD_GAZELLE_CPP=${BUILD_GAZELLE_CPP}
+  make -j$NPROC
 fi

--- a/cpp/gazelle-cpp/CMakeLists.txt
+++ b/cpp/gazelle-cpp/CMakeLists.txt
@@ -16,40 +16,28 @@
 # under the License.
 
 cmake_minimum_required(VERSION 3.16)
-message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
-if (POLICY CMP0126)
-  cmake_policy(SET CMP0126 NEW)
-endif ()
+project(gazelle_cpp)
 
-if (NOT DEFINED CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE
-      Release
-      CACHE STRING "Choose the type of build.")
-endif ()
+include(ExternalProject)
+include(FindPkgConfig)
+include(GNUInstallDirs)
+include(CheckCXXCompilerFlag)
 
-project(spark_columnar_plugin)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(DEBUG "Enable Debug Info" OFF)
-option(BUILD_TESTS "Build Tests" OFF)
-option(BUILD_GAZELLE_CPP "Build the gazelle-cpp libraries" OFF)
+find_package(JNI REQUIRED)
 
-set(root_directory ${PROJECT_BINARY_DIR})
+set(GAZELLE_CPP_JNI_SRCS
+    jni/jni_wrapper.cc
+    )
 
-#
-# Compiler flags
-#
+add_library(gazelle_cpp SHARED ${GAZELLE_CPP_JNI_SRCS})
 
-if (DEBUG)
-  add_definitions(-DDEBUG)
-endif ()
+target_include_directories(gazelle_cpp PUBLIC ${CMAKE_SYSTEM_INCLUDE_PATH} ${JNI_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR} ${root_directory}/src)
+target_link_libraries(gazelle_cpp spark_columnar_jni)
 
-#
-# Subdirectories
-#
-
-add_subdirectory(src)
-
-if (BUILD_GAZELLE_CPP)
-  add_subdirectory(gazelle-cpp)
-endif ()
+set_target_properties(gazelle_cpp PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${root_directory}/releases
+    )

--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -15,21 +15,11 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "substrait_arrow.h"
 
-#include <arrow/status.h>
-#include <arrow/type_fwd.h>
+namespace gazellecpp {
+namespace compute {
 
-struct Metrics {
-  int num_metrics;
-  long* process_time;
-  long* output_length;
-  Metrics(int size) : num_metrics(size) {
-    process_time = new long[num_metrics];
-    output_length = new long[num_metrics];
-  }
-  ~Metrics() {
-    delete[] process_time;
-    delete[] output_length;
-  }
-};
+
+}  // namespace compute
+}  // namespace gazellecpp

--- a/cpp/gazelle-cpp/compute/substrait_arrow.h
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.h
@@ -17,19 +17,29 @@
 
 #pragma once
 
-#include <arrow/status.h>
-#include <arrow/type_fwd.h>
+#include "compute/substrait_utils.h"
 
-struct Metrics {
-  int num_metrics;
-  long* process_time;
-  long* output_length;
-  Metrics(int size) : num_metrics(size) {
-    process_time = new long[num_metrics];
-    output_length = new long[num_metrics];
+namespace gazellecpp {
+namespace compute {
+
+class ArrowSubstraitParser : public gazellejni::ExecBackendBase {
+ public:
+  ArrowSubstraitParser() {
+    delegate_ = std::make_unique<gazellejni::compute::SubstraitParser>();
   }
-  ~Metrics() {
-    delete[] process_time;
-    delete[] output_length;
+
+  std::shared_ptr<gazellejni::RecordBatchResultIterator> GetResultIterator() override {
+    return delegate_->GetResultIterator();
   }
+
+  std::shared_ptr<gazellejni::RecordBatchResultIterator> GetResultIterator(
+      std::vector<std::shared_ptr<gazellejni::RecordBatchResultIterator>> inputs) override {
+    return delegate_->GetResultIterator();
+  }
+
+ private:
+  std::unique_ptr<gazellejni::compute::SubstraitParser> delegate_;
 };
+
+}  // namespace compute
+}  // namespace gazellecpp

--- a/cpp/gazelle-cpp/jni/jni_wrapper.cc
+++ b/cpp/gazelle-cpp/jni/jni_wrapper.cc
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+
+#include "compute/substrait_arrow.h"
+#include "compute/substrait_utils.h"
+
+static jint JNI_VERSION = JNI_VERSION_1_8;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+  JNIEnv* env;
+  if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION) != JNI_OK) {
+    return JNI_ERR;
+  }
+  std::cout << "loaded gazelle_cpp" << std::endl;
+  return JNI_VERSION;
+}
+
+void JNI_OnUnload(JavaVM* vm, void* reserved) {
+  JNIEnv* env;
+  vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION);
+}
+
+JNIEXPORT void JNICALL
+Java_com_intel_oap_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(
+    JNIEnv* env, jobject obj) {
+  gazellejni::SetBackendFactory(
+      [] { return std::make_shared<gazellecpp::compute::ArrowSubstraitParser>(); });
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 cmake_minimum_required(VERSION 3.16)
 
 project(spark_columnar_jni)
@@ -11,13 +28,13 @@ set(CMAKE_CXX_STANDARD 14)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_BUILD_TYPE  "Release")
-
 set(ARROW_ROOT "/usr/local" CACHE PATH "Arrow Root dir")
 set(ARROW_BFS_INSTALL_DIR "/usr/local" CACHE PATH "Arrow Build from Source dir")
 set(ARROW_LIB_NAME arrow)
 set(GANDIVA_LIB_NAME gandiva)
-set(ARROW_SHARED_LIBRARY_SUFFIX ".so.400")
+set(ARROW_SHARED_LIBRARY_SUFFIX ".so.700")
+set(ARROW_SHARED_LIB_NAME ${CMAKE_SHARED_LIBRARY_PREFIX}${ARROW_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX})
+set(GANDIVA_SHARED_LIB_NAME ${CMAKE_SHARED_LIBRARY_PREFIX}${GANDIVA_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX})
 
 option(BUILD_ARROW "Build Arrow from Source" ON)
 option(STATIC_ARROW "Build Arrow with Static Libraries" OFF)
@@ -26,7 +43,6 @@ option(USE_AVX512 "Build with AVX-512 optimizations" OFF)
 option(TESTS "Build the tests" OFF)
 option(BENCHMARKS "Build the benchmarks" OFF)
 option(BUILD_JEMALLOC "Build Jemalloc from Source" OFF)
-option(DEBUG "Enable Debug Info" OFF)
 
 set(BOOST_MIN_VERSION "1.42.0")
 find_package(Boost REQUIRED)
@@ -113,10 +129,6 @@ macro(find_protobuf)
   set(PROTOC_BIN ${Protobuf_PROTOC_EXECUTABLE})
 endmacro()
 
-if(DEBUG)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -DDEBUG -DDEBUG_LEVEL_1 -DDEBUG_LEVEL_2")
-endif()
-
 if(USE_AVX512)
   # Only enable additional instruction sets if they are supported
   message(STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
@@ -148,7 +160,7 @@ macro(build_arrow STATIC_ARROW)
                       INSTALL_DIR ${ARROW_PREFIX}
                       INSTALL_COMMAND make install
                       SOURCE_SUBDIR cpp
-                      CMAKE_ARGS 
+                      CMAKE_ARGS
                       -DARROW_BUILD_STATIC=OFF
                       -DARROW_BUILD_SHARED=ON
                       -DARROW_COMPUTE=ON
@@ -222,16 +234,16 @@ macro(build_arrow STATIC_ARROW)
 
   else()
 
-    ExternalProject_Add_Step(arrow_ep copy_arrow_binary_400_0_0
-                      COMMAND cp -a ${ARROW_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${ARROW_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX} ${root_directory}/releases/
-                      COMMENT "Copy libarrow.so.400.0.0 to releases/"
+    ExternalProject_Add_Step(arrow_ep copy_arrow_binary
+                      COMMAND cp -a ${ARROW_PREFIX}/lib/${ARROW_SHARED_LIB_NAME} ${root_directory}/releases/
+                      COMMENT "Copy ${ARROW_SHARED_LIB_NAME} to releases/"
                       DEPENDEES mkdir download update patch configure build install java_install
                       WORKING_DIRECTORY "${ARROW_PREFIX}/"
     )
 
-    ExternalProject_Add_Step(arrow_ep copy_gandiva_binary_400_0_0
-                      COMMAND cp -a ${ARROW_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${GANDIVA_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX} ${root_directory}/releases/
-                      COMMENT "Copy libgandiva.so.400.0.0 to releases/"
+    ExternalProject_Add_Step(arrow_ep copy_gandiva_binary
+                      COMMAND cp -a ${ARROW_PREFIX}/lib/${GANDIVA_SHARED_LIB_NAME} ${root_directory}/releases/
+                      COMMENT "Copy ${GANDIVA_SHARED_LIB_NAME} to releases/"
                       DEPENDEES mkdir download update patch configure build install java_install
                       WORKING_DIRECTORY "${ARROW_PREFIX}/"
     )
@@ -248,7 +260,7 @@ macro(build_arrow STATIC_ARROW)
     # Set up Arrow Shared Library Directory
     set(
       ARROW_SHARED_LIB
-      "${root_directory}/releases/${CMAKE_SHARED_LIBRARY_PREFIX}${ARROW_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX}"
+      "${root_directory}/releases/${ARROW_SHARED_LIB_NAME}"
       )
     add_library(Arrow::arrow SHARED IMPORTED)
     set_target_properties(Arrow::arrow
@@ -260,7 +272,7 @@ macro(build_arrow STATIC_ARROW)
     # Set up Gandiva Shared Library Directory
     set(
       GANDIVA_SHARED_LIB
-      "${root_directory}/releases/${CMAKE_SHARED_LIBRARY_PREFIX}${GANDIVA_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX}"
+      "${root_directory}/releases/${GANDIVA_SHARED_LIB_NAME}"
       )
     add_library(Arrow::gandiva SHARED IMPORTED)
     set_target_properties(Arrow::gandiva
@@ -284,14 +296,14 @@ macro(find_arrow)
   set(ARROW_INCLUDE_DIR "${ARROW_ROOT}/include")
   message(STATUS "Set Arrow Include Directory in ${ARROW_BFS_INCLUDE_DIR} or ${ARROW_INCLUDE_DIR}")
 
-  find_library(ARROW_LIB NAMES ${CMAKE_SHARED_LIBRARY_PREFIX}${ARROW_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX} PATHS ${ARROW_BFS_LIB_DIR} ${ARROW_LIB_DIR} ${ARROW_LIB64_DIR} NO_DEFAULT_PATH)
+  find_library(ARROW_LIB NAMES ${ARROW_SHARED_LIB_NAME} PATHS ${ARROW_BFS_LIB_DIR} ${ARROW_LIB_DIR} ${ARROW_LIB64_DIR} NO_DEFAULT_PATH)
   if(NOT ARROW_LIB)
     message(FATAL_ERROR "Arrow Library Not Found")
   else()
     message(STATUS "Arrow Library Can Be Found in ${ARROW_LIB}")
   endif()
 
-  find_library(GANDIVA_LIB NAMES ${CMAKE_SHARED_LIBRARY_PREFIX}${GANDIVA_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX} PATHS ${ARROW_BFS_LIB_DIR} ${ARROW_LIB_DIR} ${ARROW_LIB64_DIR} NO_DEFAULT_PATH)
+  find_library(GANDIVA_LIB NAMES ${GANDIVA_SHARED_LIB_NAME} PATHS ${ARROW_BFS_LIB_DIR} ${ARROW_LIB_DIR} ${ARROW_LIB64_DIR} NO_DEFAULT_PATH)
   if(NOT GANDIVA_LIB)
     message(FATAL_ERROR "Gandiva Library Not Found")
   else()
@@ -316,7 +328,7 @@ macro(find_arrow)
   # Set up Arrow Shared Library Directory
   set(
     ARROW_SHARED_LIB
-    "${root_directory}/releases/${CMAKE_SHARED_LIBRARY_PREFIX}${ARROW_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX}"
+    "${root_directory}/releases/${ARROW_SHARED_LIB_NAME}"
     )
 
   add_library(Arrow::arrow SHARED IMPORTED)
@@ -328,7 +340,7 @@ macro(find_arrow)
   # Set up Gandiva Shared Library Directory
   set(
     GANDIVA_SHARED_LIB
-    "${root_directory}/releases/${CMAKE_SHARED_LIBRARY_PREFIX}${GANDIVA_LIB_NAME}${ARROW_SHARED_LIBRARY_SUFFIX}"
+    "${root_directory}/releases/${GANDIVA_SHARED_LIB_NAME}"
     )
   add_library(Arrow::gandiva SHARED IMPORTED)
   set_target_properties(Arrow::gandiva
@@ -440,6 +452,7 @@ add_definitions(-DNATIVESQL_SRC_PATH="${root_directory}/releases")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-attributes")
 set(SPARK_COLUMNAR_PLUGIN_SRCS
         jni/jni_wrapper.cc
+        jni/exec_backend.cc
         ${PROTO_SRCS}
         compute/protobuf_utils.cc
         compute/substrait_utils.cc
@@ -497,6 +510,37 @@ if(BUILD_JEMALLOC)
 else() #
   find_jemalloc()
   message(STATUS "Use existing Jemalloc libraries")
+endif()
+
+if(BUILD_TESTS)
+  enable_testing()
+  include(GoogleTest)
+  find_package(GTest REQUIRED)
+
+  function(ADD_TEST_CASE TEST_NAME)
+    set(options)
+    set(one_value_args)
+    set(multi_value_args
+        SOURCES)
+
+    cmake_parse_arguments(ARG
+                          "${options}"
+                          "${one_value_args}"
+                          "${multi_value_args}"
+                          ${ARGN})
+
+    if(ARG_SOURCES)
+      set(SOURCES ${ARG_SOURCES})
+    else()
+      message(FATAL_ERROR "No sources specified for test ${TEST_NAME}")
+    endif()
+
+    add_executable(${TEST_NAME} ${SOURCES})
+    target_link_libraries(${TEST_NAME} gtest gtest_main spark_columnar_jni)
+    gtest_discover_tests(${TEST_NAME})
+  endfunction()
+
+  add_test_case(exec_backend_test SOURCES jni/exec_backend_test.cc)
 endif()
 
 if(DEFINED ENV{HADOOP_HOME})

--- a/cpp/src/compute/protobuf_utils.cc
+++ b/cpp/src/compute/protobuf_utils.cc
@@ -416,7 +416,7 @@ SchemaPtr ProtoTypeToSchema(const exprs::Schema& schema) {
 
 // Common for both projector and filters.
 
-bool ParseProtobuf(uint8_t* buf, int bufLen, google::protobuf::Message* msg) {
+bool ParseProtobuf(const uint8_t* buf, int bufLen, google::protobuf::Message* msg) {
   google::protobuf::io::CodedInputStream cis(buf, bufLen);
   cis.SetRecursionLimit(1000);
   return msg->ParseFromCodedStream(&cis);
@@ -424,10 +424,11 @@ bool ParseProtobuf(uint8_t* buf, int bufLen, google::protobuf::Message* msg) {
 
 inline google::protobuf::util::TypeResolver* GetGeneratedTypeResolver() {
   static std::unique_ptr<google::protobuf::util::TypeResolver> type_resolver;
-  if (!type_resolver) {
+  static std::once_flag type_resolver_init;
+  std::call_once(type_resolver_init, []() {
     type_resolver.reset(google::protobuf::util::NewTypeResolverForDescriptorPool(
         /*url_prefix=*/"", google::protobuf::DescriptorPool::generated_pool()));
-  }
+  });
   return type_resolver.get();
 }
 

--- a/cpp/src/compute/protobuf_utils.h
+++ b/cpp/src/compute/protobuf_utils.h
@@ -66,7 +66,7 @@ ExpressionPtr ProtoTypeToExpression(const exprs::ExpressionRoot& root);
 ConditionPtr ProtoTypeToCondition(const exprs::Condition& condition);
 SchemaPtr ProtoTypeToSchema(const exprs::Schema& schema);
 // Common for both projector and filters.
-bool ParseProtobuf(uint8_t* buf, int bufLen, google::protobuf::Message* msg);
+bool ParseProtobuf(const uint8_t* buf, int bufLen, google::protobuf::Message* msg);
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> SubstraitFromJSON(
     arrow::util::string_view type_name, arrow::util::string_view json);

--- a/cpp/src/compute/substrait_utils.h
+++ b/cpp/src/compute/substrait_utils.h
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#pragma once
+
+#include "jni/exec_backend.h"
 #include "substrait/algebra.pb.h"
 #include "substrait/capabilities.pb.h"
 #include "substrait/extensions/extensions.pb.h"
@@ -28,7 +31,7 @@
 namespace gazellejni {
 namespace compute {
 
-class SubstraitParser {
+class SubstraitParser : public ExecBackendBase {
  public:
   SubstraitParser();
   void ParseLiteral(const substrait::Expression::Literal& slit);
@@ -45,7 +48,9 @@ class SubstraitParser {
   void ParseRelRoot(const substrait::RelRoot& sroot);
   void ParseRel(const substrait::Rel& srel);
   void ParsePlan(const substrait::Plan& splan);
-  std::shared_ptr<ResultIterator<arrow::RecordBatch>> getResIter();
+  std::shared_ptr<RecordBatchResultIterator> GetResultIterator() override;
+  std::shared_ptr<RecordBatchResultIterator> GetResultIterator(
+      std::vector<std::shared_ptr<RecordBatchResultIterator>> inputs) override;
 
  private:
   std::string FindFunction(uint64_t id);

--- a/cpp/src/jni/exec_backend.cc
+++ b/cpp/src/jni/exec_backend.cc
@@ -25,15 +25,12 @@
 namespace gazellejni {
 
 static std::function<std::shared_ptr<ExecBackendBase>()> backend_factory;
-static std::once_flag backend_factory_initialized_;
 
 void SetBackendFactory(std::function<std::shared_ptr<ExecBackendBase>()> factory) {
-  std::call_once(backend_factory_initialized_, [&factory]() {
 #ifdef DEBUG
-    std::cout << "Set backend factory." << std::endl;
+  std::cout << "Set backend factory." << std::endl;
 #endif
-    backend_factory = std::move(factory);
-  });
+  backend_factory = std::move(factory);
 }
 
 std::shared_ptr<ExecBackendBase> CreateBackend() {

--- a/cpp/src/jni/exec_backend.cc
+++ b/cpp/src/jni/exec_backend.cc
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec_backend.h"
+
+#include <mutex>
+#include <utility>
+
+#include "compute/substrait_utils.h"
+
+namespace gazellejni {
+
+static std::function<std::shared_ptr<ExecBackendBase>()> backend_factory;
+static std::once_flag backend_factory_initialized_;
+
+void SetBackendFactory(std::function<std::shared_ptr<ExecBackendBase>()> factory) {
+  std::call_once(backend_factory_initialized_, [&factory]() {
+#ifdef DEBUG
+    std::cout << "Set backend factory." << std::endl;
+#endif
+    backend_factory = std::move(factory);
+  });
+}
+
+std::shared_ptr<ExecBackendBase> CreateBackend() {
+  if (backend_factory == nullptr) {
+    std::cout
+        << "Execution backend not set. This may due to the backend library not "
+           "loaded, or SetBackendFactory() is not called in nativeInitNative() JNI call."
+           " Will create default backend, which is only served as an example."
+        << std::endl;
+    return std::make_shared<compute::SubstraitParser>();
+  }
+  return backend_factory();
+}
+
+}  // namespace gazellejni

--- a/cpp/src/jni/exec_backend.h
+++ b/cpp/src/jni/exec_backend.h
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <arrow/jniutil/jni_util.h>
+#include <arrow/record_batch.h>
+
+#include "compute/protobuf_utils.h"
+#include "substrait/plan.pb.h"
+#include "utils/exception.h"
+
+namespace gazellejni {
+
+class ExecBackendBase;
+
+template <typename T>
+class ResultIteratorBase {
+ public:
+  virtual ~ResultIteratorBase() = default;
+
+  virtual void Init() {}   // unused
+  virtual void Close() {}  // unused
+  virtual bool HasNext() = 0;
+  virtual std::shared_ptr<T> Next() = 0;
+};
+
+class RecordBatchResultIterator : public ResultIteratorBase<arrow::RecordBatch> {
+ public:
+  /// \brief Iterator may be constructed from any type which has a member function
+  /// with signature arrow::Result<std::shared_ptr<arrow::RecordBatch>> Next();
+  /// and will be wrapped in arrow::RecordBatchIterator.
+  /// For details, please see <arrow/util/iterator.h>
+  /// This class is used as input/output iterator for ExecBackendBase. As output,
+  /// it can hold the backend to tie their lifetimes, which can be used when the
+  /// production of the iterator relies on the backend.
+  template <typename T>
+  explicit RecordBatchResultIterator(std::shared_ptr<T> iter,
+                                     std::shared_ptr<ExecBackendBase> backend = nullptr)
+      : iter_(std::make_shared<arrow::RecordBatchIterator>(Wrapper<T>(std::move(iter)))),
+        next_(nullptr),
+        backend_(std::move(backend)) {}
+
+  bool HasNext() override {
+    GetNext();
+    return next_ != nullptr;
+  }
+
+  std::shared_ptr<arrow::RecordBatch> Next() override {
+    GetNext();
+    return std::move(next_);
+  }
+
+  std::shared_ptr<arrow::RecordBatchIterator> ToArrowRecordBatchIterator() {
+    return iter_;
+  }
+
+ private:
+  template <typename T>
+  class Wrapper {
+   public:
+    explicit Wrapper(std::shared_ptr<T> ptr) : ptr_(std::move(ptr)) {}
+
+    arrow::Result<std::shared_ptr<arrow::RecordBatch>> Next() { return ptr_->Next(); }
+
+   private:
+    std::shared_ptr<T> ptr_;
+  };
+
+  std::shared_ptr<arrow::RecordBatchIterator> iter_;
+  std::shared_ptr<arrow::RecordBatch> next_;
+  std::shared_ptr<ExecBackendBase> backend_;
+
+  void GetNext() {
+    if (next_ == nullptr) {
+      GAZELLE_JNI_ASSIGN_OR_THROW(next_, iter_->Next());
+    }
+  }
+};
+
+class ExecBackendBase : public std::enable_shared_from_this<ExecBackendBase> {
+ public:
+  virtual ~ExecBackendBase() = default;
+  virtual std::shared_ptr<RecordBatchResultIterator> GetResultIterator() = 0;
+  virtual std::shared_ptr<RecordBatchResultIterator> GetResultIterator(
+      std::vector<std::shared_ptr<RecordBatchResultIterator>> inputs) = 0;
+
+  /// Parse and cache the plan.
+  /// Return true if parsed successfully.
+  bool ParsePlan(const uint8_t* data, int32_t size) {
+#ifdef DEBUG
+    auto buf = std::make_shared<arrow::Buffer>(data, size);
+    auto maybe_plan_json = SubstraitToJSON("Plan", *buf);
+    if (maybe_plan_json.status().ok()) {
+      std::cout << std::string(50, '#') << " received substrait::Plan:" << std::endl;
+      std::cout << maybe_plan_json.ValueOrDie() << std::endl;
+    } else {
+      std::cout << "Error parsing substrait plan to json" << std::endl;
+    }
+#endif
+    google::protobuf::io::ArrayInputStream buf_stream{data, size};
+    return plan_.ParseFromZeroCopyStream(&buf_stream);
+  }
+
+  /// Parse and get the input schema from cached plan.
+  std::shared_ptr<arrow::Schema> GetInputSchema() {
+    // TODO: parse schema
+    auto schema = arrow::schema({});
+    return std::move(schema);
+  }
+
+ protected:
+  substrait::Plan plan_;
+};
+
+void SetBackendFactory(std::function<std::shared_ptr<ExecBackendBase>()> factory);
+
+std::shared_ptr<ExecBackendBase> CreateBackend();
+
+}  // namespace gazellejni

--- a/cpp/src/jni/exec_backend_test.cc
+++ b/cpp/src/jni/exec_backend_test.cc
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec_backend.h"
+
+#include <gtest/gtest.h>
+
+namespace gazellejni {
+
+class DummyBackend : public ExecBackendBase {
+ public:
+  std::shared_ptr<RecordBatchResultIterator> GetResultIterator() override {
+    auto res_iter = std::make_shared<ResultIterator>();
+    return std::make_shared<RecordBatchResultIterator>(std::move(res_iter));
+  }
+  std::shared_ptr<RecordBatchResultIterator> GetResultIterator(
+      std::vector<std::shared_ptr<RecordBatchResultIterator>> inputs) {
+    return GetResultIterator();
+  }
+
+ private:
+  class ResultIterator {
+   public:
+    arrow::Result<std::shared_ptr<arrow::RecordBatch>> Next() {
+      if (!has_next_) {
+        return nullptr;
+      }
+      has_next_ = false;
+
+      std::unique_ptr<arrow::ArrayBuilder> tmp;
+      std::unique_ptr<arrow::DoubleBuilder> builder;
+      std::shared_ptr<arrow::Array> array;
+      RETURN_NOT_OK(
+          arrow::MakeBuilder(arrow::default_memory_pool(), arrow::float64(), &tmp));
+      builder.reset(
+          arrow::internal::checked_cast<arrow::DoubleBuilder*>(tmp.release()));
+
+      RETURN_NOT_OK(builder->Append(1000));
+      RETURN_NOT_OK(builder->Finish(&array));
+      std::vector<std::shared_ptr<arrow::Field>> ret_types = {
+          arrow::field("res", arrow::float64())};
+      return arrow::RecordBatch::Make(arrow::schema(ret_types), 1, {array});
+    }
+
+   private:
+    bool has_next_ = true;
+  };
+};
+
+TEST(TestExecBackend, CreateBackend) {
+  SetBackendFactory([] { return std::make_shared<DummyBackend>(); });
+  auto backend = CreateBackend();
+  ASSERT_EQ(typeid(*backend), typeid(DummyBackend));
+}
+
+TEST(TestExecBackend, GetResultIterator) {
+  auto backend = std::make_shared<DummyBackend>();
+  auto iter = backend->GetResultIterator();
+  ASSERT_TRUE(iter->HasNext());
+  auto next = iter->Next();
+  ASSERT_NE(next, nullptr);
+  ASSERT_FALSE(iter->HasNext());
+  next = iter->Next();
+  ASSERT_EQ(next, nullptr);
+}
+
+}  // namespace gazellejni

--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -37,12 +37,16 @@
 
 #include "compute/protobuf_utils.h"
 #include "jni/concurrent_map.h"
+#include "jni/exec_backend.h"
 #include "jni/jni_common.h"
 #include "operators/c2r/columnar_to_row_converter.h"
 #include "operators/shuffle/splitter.h"
+#include "utils/exception.h"
 #include "utils/result_iterator.h"
 
 namespace {
+
+using gazellejni::JniPendingException;
 
 #define JNI_METHOD_START try {
 // macro ended
@@ -54,11 +58,6 @@ namespace {
     return fallback_expr;                             \
   }
 // macro ended
-
-class JniPendingException : public std::runtime_error {
- public:
-  explicit JniPendingException(const std::string& arg) : runtime_error(arg) {}
-};
 
 void ThrowPendingException(const std::string& message) {
   throw JniPendingException(message);
@@ -123,11 +122,12 @@ using arrow::jni::ConcurrentMap;
 static jint JNI_VERSION = JNI_VERSION_1_8;
 
 using ColumnarToRowConverter = gazellejni::columnartorow::ColumnarToRowConverter;
-static arrow::jni::ConcurrentMap<std::shared_ptr<ResultIteratorBase>>
-    batch_iterator_holder_;
-
 static arrow::jni::ConcurrentMap<std::shared_ptr<ColumnarToRowConverter>>
     columnar_to_row_converter_holder_;
+
+using gazellejni::RecordBatchResultIterator;
+static arrow::jni::ConcurrentMap<std::shared_ptr<RecordBatchResultIterator>>
+    batch_iterator_holder_;
 
 using gazellejni::shuffle::SplitOptions;
 using gazellejni::shuffle::Splitter;
@@ -135,19 +135,13 @@ static arrow::jni::ConcurrentMap<std::shared_ptr<Splitter>> shuffle_splitter_hol
 static arrow::jni::ConcurrentMap<std::shared_ptr<arrow::Schema>>
     decompression_schema_holder_;
 
-std::shared_ptr<ResultIteratorBase> GetBatchIterator(JNIEnv* env, jlong id) {
+std::shared_ptr<RecordBatchResultIterator> GetBatchIterator(JNIEnv* env, jlong id) {
   auto handler = batch_iterator_holder_.Lookup(id);
   if (!handler) {
     std::string error_message = "invalid handler id " + std::to_string(id);
     env->ThrowNew(illegal_argument_exception_class, error_message.c_str());
   }
   return handler;
-}
-
-template <typename T>
-std::shared_ptr<ResultIterator<T>> GetBatchIterator(JNIEnv* env, jlong id) {
-  auto handler = GetBatchIterator(env, id);
-  return std::dynamic_pointer_cast<ResultIterator<T>>(handler);
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> FromBytes(
@@ -231,14 +225,12 @@ class JavaRecordBatchIteratorWrapper {
 // See Java class
 // org/apache/arrow/dataset/jni/NativeSerializedRecordBatchIterator
 //
-arrow::Result<arrow::RecordBatchIterator> MakeJavaRecordBatchIterator(
+std::shared_ptr<JavaRecordBatchIterator> MakeJavaRecordBatchIterator(
     JavaVM* vm, jobject java_serialized_record_batch_iterator,
     std::shared_ptr<arrow::Schema> schema) {
   std::shared_ptr<arrow::Schema> schema_moved = std::move(schema);
-  arrow::RecordBatchIterator itr = arrow::Iterator<std::shared_ptr<arrow::RecordBatch>>(
-      JavaRecordBatchIteratorWrapper(std::make_shared<JavaRecordBatchIterator>(
-          vm, java_serialized_record_batch_iterator, schema_moved)));
-  return itr;
+  return std::make_shared<JavaRecordBatchIterator>(
+      vm, java_serialized_record_batch_iterator, schema_moved);
 }
 
 using FileSystem = arrow::fs::FileSystem;
@@ -343,47 +335,52 @@ Java_com_intel_oap_vectorized_ExpressionEvaluatorJniWrapper_nativeSetMetricsTime
 
 JNIEXPORT jlong JNICALL
 Java_com_intel_oap_vectorized_ExpressionEvaluatorJniWrapper_nativeCreateKernelWithIterator(
-    JNIEnv* env, jobject obj, jlong memory_pool_id, jbyteArray ws_exprs_arr,
+    JNIEnv* env, jobject obj, jlong memory_pool_id, jbyteArray plan_arr,
     jobjectArray iter_arr) {
+  JNI_METHOD_START
   arrow::Status msg;
   JavaVM* vm;
   if (env->GetJavaVM(&vm) != JNI_OK) {
     std::string error_message = "Unable to get JavaVM instance";
     env->ThrowNew(io_exception_class, error_message.c_str());
   }
+
+  auto plan_data =
+      reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(plan_arr, 0));
+  auto plan_size = env->GetArrayLength(plan_arr);
+
+  auto backend = gazellejni::CreateBackend();
+  if (!backend->ParsePlan(plan_data, plan_size)) {
+    ThrowPendingException("Failed to parse plan.");
+  }
+
   // Handle the Java iters
   jsize iters_len = env->GetArrayLength(iter_arr);
-  std::vector<arrow::Result<arrow::RecordBatchIterator>> arrow_iters;
+  std::vector<std::shared_ptr<RecordBatchResultIterator>> input_iters;
   if (iters_len > 0) {
+    auto schema = backend->GetInputSchema();
     for (int idx = 0; idx < iters_len; idx++) {
       jobject iter = env->GetObjectArrayElement(iter_arr, idx);
       // IMPORTANT: DO NOT USE LOCAL REF IN DIFFERENT THREAD
       // TODO Release this in JNI Unload or dependent object's destructor
       jobject ref_iter = env->NewGlobalRef(iter);
       // FIXME: Schema should be obtained from Substrait plan.
-      std::shared_ptr<arrow::Schema> schema;
-      arrow::Result<arrow::RecordBatchIterator> rb_iter =
-          MakeJavaRecordBatchIterator(vm, ref_iter, schema);
-      arrow_iters.push_back(std::move(rb_iter));
+      auto rb_iter =
+          std::make_shared<JavaRecordBatchIterator>(vm, ref_iter, std::move(schema));
+      input_iters.push_back(
+          std::make_shared<RecordBatchResultIterator>(std::move(rb_iter)));
     }
   }
-  // Get the ws iter
-  gandiva::ExpressionVector ws_expr_vector;
-  gandiva::FieldVector ws_ret_types;
-  std::shared_ptr<ResultIterator<arrow::RecordBatch>> res_iter;
-  msg = ParseSubstraitPlan(env, ws_exprs_arr, &res_iter);
-  if (!msg.ok()) {
-    std::string error_message =
-        "failed to parse expressions protobuf, err msg is " + msg.message();
-    env->ThrowNew(io_exception_class, error_message.c_str());
-  }
-  auto ws_result_iterator = std::dynamic_pointer_cast<ResultIteratorBase>(res_iter);
-  return batch_iterator_holder_.Insert(std::move(ws_result_iterator));
-}
 
-JNIEXPORT void JNICALL
-Java_com_intel_oap_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(
-    JNIEnv* env, jobject obj) {}
+  std::shared_ptr<RecordBatchResultIterator> res_iter;
+  if (input_iters.empty()) {
+    res_iter = backend->GetResultIterator();
+  } else {
+    res_iter = backend->GetResultIterator(input_iters);
+  }
+  return batch_iterator_holder_.Insert(std::move(res_iter));
+  JNI_METHOD_END(-1)
+}
 
 JNIEXPORT jboolean JNICALL Java_com_intel_oap_vectorized_BatchIterator_nativeHasNext(
     JNIEnv* env, jobject obj, jlong id) {
@@ -400,13 +397,12 @@ JNIEXPORT jboolean JNICALL Java_com_intel_oap_vectorized_BatchIterator_nativeHas
 JNIEXPORT jobject JNICALL Java_com_intel_oap_vectorized_BatchIterator_nativeNext(
     JNIEnv* env, jobject obj, jlong id) {
   JNI_METHOD_START
-  auto iter = GetBatchIterator<arrow::RecordBatch>(env, id);
-  std::shared_ptr<arrow::RecordBatch> out;
+  auto iter = GetBatchIterator(env, id);
   if (!iter->HasNext()) return nullptr;
-  JniAssertOkOrThrow(iter->Next(&out), "nativeNext: get Next() failed");
-  jbyteArray serialized_record_batch =
-      JniGetOrThrow(ToBytes(env, out), "Error deserializing message");
-  return serialized_record_batch;
+  auto batch = std::move(iter->Next());
+  auto maybe_bytes = arrow::jniutil::SerializeUnsafeFromNative(env, batch);
+  JniAssertOkOrThrow(maybe_bytes.status());
+  return maybe_bytes.ValueOrDie();
   JNI_METHOD_END(nullptr)
 }
 
@@ -415,7 +411,7 @@ JNIEXPORT void JNICALL Java_com_intel_oap_vectorized_BatchIterator_nativeClose(
 #ifdef DEBUG
   auto it = batch_iterator_holder_.Lookup(id);
   if (it.use_count() > 2) {
-    std::cout << it->ToString() << " ptr use count is " << it.use_count() << std::endl;
+    std::cout << "Id " << id << " use count is " << it.use_count() << std::endl;
   }
 #endif
   batch_iterator_holder_.Erase(id);

--- a/cpp/src/operators/shuffle/splitter.cc
+++ b/cpp/src/operators/shuffle/splitter.cc
@@ -644,7 +644,7 @@ arrow::Status Splitter::AllocatePartitionBuffers(int32_t partition_id, int32_t n
         std::shared_ptr<arrow::ResizableBuffer> value_buffer;
         if (column_type_id_[i]->id() == arrow::BooleanType::type_id) {
           ARROW_ASSIGN_OR_RAISE(value_buffer, arrow::AllocateResizableBuffer(
-                                                  arrow::BitUtil::BytesForBits(new_size),
+                                                  arrow::bit_util::BytesForBits(new_size),
                                                   options_.memory_pool));
         } else {
           ARROW_ASSIGN_OR_RAISE(
@@ -658,7 +658,7 @@ arrow::Status Splitter::AllocatePartitionBuffers(int32_t partition_id, int32_t n
           std::shared_ptr<arrow::ResizableBuffer> validity_buffer;
           ARROW_ASSIGN_OR_RAISE(
               validity_buffer,
-              arrow::AllocateResizableBuffer(arrow::BitUtil::BytesForBits(new_size),
+              arrow::AllocateResizableBuffer(arrow::bit_util::BytesForBits(new_size),
                                              options_.memory_pool));
           new_validity_buffers.push_back(std::move(validity_buffer));
         } else {
@@ -1138,7 +1138,7 @@ arrow::Status Splitter::SplitFixedWidthValidityBuffer(const arrow::RecordBatch& 
     if (rb.column_data(col_idx)->GetNullCount() == 0) {
       for (auto pid = 0; pid < num_partitions_; ++pid) {
         if (partition_id_cnt_[pid] > 0 && dst_addrs[pid] != nullptr) {
-          arrow::BitUtil::SetBitsTo(dst_addrs[pid], partition_buffer_idx_base_[pid],
+          arrow::bit_util::SetBitsTo(dst_addrs[pid], partition_buffer_idx_base_[pid],
                                     partition_id_cnt_[pid], true);
         }
       }
@@ -1151,10 +1151,10 @@ arrow::Status Splitter::SplitFixedWidthValidityBuffer(const arrow::RecordBatch& 
                               : options_.buffer_size;
           ARROW_ASSIGN_OR_RAISE(
               auto validity_buffer,
-              arrow::AllocateResizableBuffer(arrow::BitUtil::BytesForBits(new_size),
+              arrow::AllocateResizableBuffer(arrow::bit_util::BytesForBits(new_size),
                                              options_.memory_pool));
           dst_addrs[pid] = const_cast<uint8_t*>(validity_buffer->data());
-          arrow::BitUtil::SetBitsTo(dst_addrs[pid], 0, partition_buffer_idx_base_[pid],
+          arrow::bit_util::SetBitsTo(dst_addrs[pid], 0, partition_buffer_idx_base_[pid],
                                     true);
           partition_fixed_width_buffers_[col][pid][0] = std::move(validity_buffer);
         }

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -389,6 +389,7 @@
                         <argument>${arrow_root}</argument>
                         <argument>${jvm.arrow.bfs.install.dir}</argument>
                         <argument>${build_jemalloc}</argument>
+                        <argument>${build_gazelle_cpp}</argument>
                     </arguments>
                 </configuration>
             </execution>

--- a/jvm/src/main/java/com/intel/oap/execution/ColumnarNativeIterator.java
+++ b/jvm/src/main/java/com/intel/oap/execution/ColumnarNativeIterator.java
@@ -18,12 +18,26 @@
 package com.intel.oap.execution;
 
 import com.intel.oap.expression.ConverterUtils;
-import org.apache.arrow.dataset.jni.NativeSerializedRecordBatchIterator;
 import org.apache.arrow.dataset.jni.UnsafeRecordBatchSerializer;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import java.util.Iterator;
+
+/**
+ * Iterate on flatbuffers-serialized {@link org.apache.arrow.vector.ipc.message.ArrowRecordBatch}.
+ * <p>
+ * {@link #next()} should be called from C++ scanner to read Java-generated Arrow data.
+ */
+interface NativeSerializedRecordBatchIterator extends Iterator<byte[]>, AutoCloseable {
+
+  /**
+   * Return next serialized {@link org.apache.arrow.vector.ipc.message.ArrowRecordBatch} Java
+   * byte array.
+   */
+  @Override
+  byte[] next();
+}
 
 public class ColumnarNativeIterator implements NativeSerializedRecordBatchIterator {
   private final Iterator<ColumnarBatch> delegated;

--- a/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluator.java
+++ b/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluator.java
@@ -77,9 +77,6 @@ public class ExpressionEvaluator implements AutoCloseable {
     jniWrapper.nativeSetBatchSize(GazelleJniConfig.getBatchSize());
     jniWrapper.nativeSetMetricsTime(GazelleJniConfig.getEnableMetricsTime());
     GazelleJniConfig.setRandomTempDir(jniWrapper.tmp_dir_path);
-    if (StringUtils.isNotBlank(customBackendLib)) {
-      jniWrapper.nativeInitNative();
-    }
   }
 
   long getInstanceId() {

--- a/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluator.java
+++ b/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluator.java
@@ -28,6 +28,7 @@ import org.apache.arrow.gandiva.ipc.GandivaTypes;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.memory.MemoryConsumer;
 import org.apache.spark.sql.execution.datasources.v2.arrow.SparkMemoryUtils;
 
@@ -53,27 +54,32 @@ public class ExpressionEvaluator implements AutoCloseable {
   public ExpressionEvaluator(List<String> listJars, String libName) throws IOException, IllegalAccessException, IllegalStateException {
     this(listJars, libName,
             GazelleJniConfig.getSessionConf().nativeLibPath(),
+            GazelleJniConfig.getConf().gazelleJniBackendLib(),
             GazelleJniConfig.getConf().loadArrow());
   }
 
   public ExpressionEvaluator(String libPath)
           throws IOException, IllegalAccessException, IllegalStateException {
-    this(java.util.Collections.emptyList(), null, libPath, GazelleJniConfig.getConf().loadArrow());
+    this(java.util.Collections.emptyList(), null, libPath, null, GazelleJniConfig.getConf().loadArrow());
   }
 
   public ExpressionEvaluator(List<String> listJars, String libName,
-                             String libPath, boolean loadArrowAndGandiva)
+                             String libPath, String customBackendLib,
+                             boolean loadArrowAndGandiva)
           throws IOException, IllegalAccessException, IllegalStateException {
     String tmp_dir = GazelleJniConfig.getTempFile();
     if (tmp_dir == null) {
       tmp_dir = System.getProperty("java.io.tmpdir");
     }
     jniWrapper = new ExpressionEvaluatorJniWrapper(tmp_dir, listJars, libName, libPath,
-            loadArrowAndGandiva);
+            customBackendLib, loadArrowAndGandiva);
     jniWrapper.nativeSetJavaTmpDir(jniWrapper.tmp_dir_path);
     jniWrapper.nativeSetBatchSize(GazelleJniConfig.getBatchSize());
     jniWrapper.nativeSetMetricsTime(GazelleJniConfig.getEnableMetricsTime());
     GazelleJniConfig.setRandomTempDir(jniWrapper.tmp_dir_path);
+    if (StringUtils.isNotBlank(customBackendLib)) {
+      jniWrapper.nativeInitNative();
+    }
   }
 
   long getInstanceId() {

--- a/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/jvm/src/main/java/com/intel/oap/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -34,10 +34,11 @@ public class ExpressionEvaluatorJniWrapper {
 
         /** Wrapper for native API. */
         public ExpressionEvaluatorJniWrapper(String tmp_dir, List<String> listJars, String libName,
-                                             String libPath, boolean loadArrowAndGandiva)
+                                             String libPath, String customBackendLib,
+                                             boolean loadArrowAndGandiva)
                         throws IOException, IllegalAccessException, IllegalStateException {
                 JniInstance jni = JniInstance
-                        .getInstance(tmp_dir, libName, libPath, loadArrowAndGandiva);
+                        .getInstance(tmp_dir, libName, libPath, customBackendLib, loadArrowAndGandiva);
                 jni.setTempDir();
                 jni.setJars(listJars);
                 tmp_dir_path = jni.getTempDir();

--- a/jvm/src/main/java/com/intel/oap/vectorized/JniInstance.java
+++ b/jvm/src/main/java/com/intel/oap/vectorized/JniInstance.java
@@ -41,10 +41,10 @@ import java.util.jar.JarFile;
 public class JniInstance {
   /** Default names for native backend, Arrow and Gandiva libraries. */
   private static final String LIBRARY_NAME = "spark_columnar_jni";
-  private static final String ARROW_LIBRARY_NAME = "libarrow.so.400.0.0";
-  private static final String ARROW_PARENT_LIBRARY_NAME = "libarrow.so.400";
-  private static final String GANDIVA_LIBRARY_NAME = "libgandiva.so.400.0.0";
-  private static final String GANDIVA_PARENT_LIBRARY_NAME = "libgandiva.so.400";
+  private static final String ARROW_LIBRARY_NAME = "libarrow.so.700.0.0";
+  private static final String ARROW_PARENT_LIBRARY_NAME = "libarrow.so.700";
+  private static final String GANDIVA_LIBRARY_NAME = "libgandiva.so.700.0.0";
+  private static final String GANDIVA_PARENT_LIBRARY_NAME = "libgandiva.so.700";
   private static boolean isLoaded = false;
   private static boolean isCodegenDependencyLoaded = false;
   private static List<String> codegenJarsLoadedCache = new ArrayList<>();
@@ -57,16 +57,16 @@ public class JniInstance {
   }
 
   public static JniInstance getInstance(String tmp_dir) throws IOException {
-    return getInstance(tmp_dir, null, null, true);
+    return getInstance(tmp_dir, null, null, null, true);
   }
 
-  public static JniInstance getInstance(String tmp_dir, String lib_name, String libPath,
+  public static JniInstance getInstance(String tmp_dir, String lib_name, String libPath, String customBackendLib,
                                         boolean loadArrowAndGandiva) throws IOException {
     if (INSTANCE == null) {
       synchronized (JniInstance.class) {
         if (INSTANCE == null) {
           try {
-            INSTANCE = new JniInstance(tmp_dir, lib_name, libPath, loadArrowAndGandiva);
+            INSTANCE = new JniInstance(tmp_dir, lib_name, libPath, customBackendLib, loadArrowAndGandiva);
           } catch (IllegalAccessException ex) {
             throw new IOException("IllegalAccess", ex);
           }
@@ -76,7 +76,7 @@ public class JniInstance {
     return INSTANCE;
   }
 
-  private JniInstance(String _tmp_dir, String _lib_name, String libPath,
+  private JniInstance(String _tmp_dir, String _lib_name, String libPath, String customBackendLib,
                       boolean loadArrowAndGandiva)
           throws IOException, IllegalAccessException, IllegalStateException {
     if (!isLoaded) {
@@ -92,6 +92,9 @@ public class JniInstance {
           loadLibraryFromLibPath(tmp_dir, libPath, loadArrowAndGandiva);
         } else {
           loadLibraryFromJarWithLib(tmp_dir, _lib_name, loadArrowAndGandiva);
+          if (StringUtils.isNotBlank(customBackendLib)) {
+            loadLibraryFromJarWithLib(tmp_dir, customBackendLib, false);
+          }
         }
       } catch (IOException ex) {
         if (_lib_name != null) {

--- a/jvm/src/main/scala/com/intel/oap/GazelleJniConfig.scala
+++ b/jvm/src/main/scala/com/intel/oap/GazelleJniConfig.scala
@@ -161,6 +161,10 @@ class GazelleJniConfig(conf: SQLConf) extends Logging {
   val nativeLibPath: String =
     conf.getConfString(GazelleJniConfig.OAP_LIB_PATH, "")
 
+  // customized backend library name
+  val gazelleJniBackendLib: String =
+    conf.getConfString(GazelleJniConfig.GAZELLE_JNI_BACKEND_LIB, "")
+
   // fallback to row operators if there are several continous joins
   val joinOptimizationThrottle: Integer =
     conf.getConfString("spark.oap.sql.columnar.joinOptimizationLevel", "12").toInt

--- a/jvm/src/main/scala/com/intel/oap/GazelleJniConfig.scala
+++ b/jvm/src/main/scala/com/intel/oap/GazelleJniConfig.scala
@@ -19,6 +19,8 @@ package com.intel.oap
 
 import java.util.Locale
 
+import com.intel.oap.GazelleJniConfig.GAZELLE_JNI_BACKEND_LIB
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.SQLConf
 
@@ -67,7 +69,7 @@ class GazelleJniConfig(conf: SQLConf) extends Logging {
   // enable or disable columnar sort
   val enableColumnarSort: Boolean =
     conf.getConfString("spark.oap.sql.columnar.sort", "true").toBoolean && enableCpu
-  
+
   // enable or disable codegen columnar sort
   val enableColumnarCodegenSort: Boolean = conf.getConfString(
     "spark.oap.sql.columnar.codegen.sort", "true").toBoolean && enableColumnarSort
@@ -75,7 +77,7 @@ class GazelleJniConfig(conf: SQLConf) extends Logging {
   // enable or disable columnar window
   val enableColumnarWindow: Boolean =
     conf.getConfString("spark.oap.sql.columnar.window", "true").toBoolean && enableCpu
-  
+
   // enable or disable columnar shuffledhashjoin
   val enableColumnarShuffledHashJoin: Boolean =
     conf.getConfString("spark.oap.sql.columnar.shuffledhashjoin", "true").toBoolean && enableCpu
@@ -110,7 +112,7 @@ class GazelleJniConfig(conf: SQLConf) extends Logging {
   // enable or disable NAN check
   val enableColumnarNaNCheck: Boolean =
     conf.getConfString("spark.oap.sql.columnar.nanCheck", "true").toBoolean
-  
+
   // enable or disable hashcompare in hashjoins or hashagg
   val hashCompare: Boolean =
     conf.getConfString("spark.oap.sql.columnar.hashCompare", "true").toBoolean
@@ -126,7 +128,7 @@ class GazelleJniConfig(conf: SQLConf) extends Logging {
   // enable or disable columnar wholestagecodegen
   val enableColumnarWholeStageCodegen: Boolean = conf.getConfString(
     "spark.oap.sql.columnar.wholestagetransform", "true").toBoolean && enableCpu
-  
+
   // enable or disable columnar exchange
   val enableColumnarShuffle: Boolean = conf
     .getConfString("spark.shuffle.manager", "sort")
@@ -171,7 +173,7 @@ class GazelleJniConfig(conf: SQLConf) extends Logging {
     conf.getConfString(
       "spark.oap.sql.columnar.wholestagecodegen.breakdownTime",
       "false").toBoolean
-  
+
   // a folder to store the codegen files
   val tmpFile: String =
     conf.getConfString("spark.oap.sql.columnar.tmp_dir", null)
@@ -224,6 +226,8 @@ object GazelleJniConfig {
   val OAP_LIB_NAME = "spark.oap.sql.columnar.libname"
   val OAP_LIB_PATH = "spark.oap.sql.columnar.libpath"
   val OAP_LOAD_ARROW = "spark.oap.sql.columnar.loadarrow"
+
+  val GAZELLE_JNI_BACKEND_LIB = "spark.oap.sql.columnar.backend.lib"
 
   var ins: GazelleJniConfig = null
   var random_temp_dir_path: String = null

--- a/jvm/src/main/scala/com/intel/oap/GazellePlugin.scala
+++ b/jvm/src/main/scala/com/intel/oap/GazellePlugin.scala
@@ -64,11 +64,16 @@ private[oap] class GazelleExecutorPlugin extends ExecutorPlugin {
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
     // SQLConf is not initialed here, so it can not use 'GazelleJniConfig.getConf' to get conf.
     if (ctx.conf().getBoolean(GazelleJniConfig.OAP_LOAD_NATIVE, defaultValue = true)) {
+      val customOAPLib = ctx.conf().get(GazelleJniConfig.OAP_LIB_PATH, "")
+      val customBackendLib = ctx.conf().get(GazelleJniConfig.GAZELLE_JNI_BACKEND_LIB, "")
       val initKernel = new ExpressionEvaluator(java.util.Collections.emptyList[String],
         ctx.conf().get(GazelleJniConfig.OAP_LIB_NAME, "spark_columnar_jni"),
-        ctx.conf().get(GazelleJniConfig.OAP_LIB_PATH, ""),
-        ctx.conf().get(GazelleJniConfig.GAZELLE_JNI_BACKEND_LIB, ""),
+        customOAPLib,
+        customBackendLib,
         ctx.conf().getBoolean(GazelleJniConfig.OAP_LOAD_ARROW, defaultValue = true))
+      if (customOAPLib.nonEmpty || customBackendLib.nonEmpty) {
+        initKernel.initNative()
+      }
     }
   }
 

--- a/jvm/src/main/scala/com/intel/oap/GazellePlugin.scala
+++ b/jvm/src/main/scala/com/intel/oap/GazellePlugin.scala
@@ -67,8 +67,8 @@ private[oap] class GazelleExecutorPlugin extends ExecutorPlugin {
       val initKernel = new ExpressionEvaluator(java.util.Collections.emptyList[String],
         ctx.conf().get(GazelleJniConfig.OAP_LIB_NAME, "spark_columnar_jni"),
         ctx.conf().get(GazelleJniConfig.OAP_LIB_PATH, ""),
+        ctx.conf().get(GazelleJniConfig.GAZELLE_JNI_BACKEND_LIB, ""),
         ctx.conf().getBoolean(GazelleJniConfig.OAP_LOAD_ARROW, defaultValue = true))
-      initKernel.initNative()
     }
   }
 

--- a/jvm/src/main/scala/com/intel/oap/execution/NativeWholeStageColumnarRDD.scala
+++ b/jvm/src/main/scala/com/intel/oap/execution/NativeWholeStageColumnarRDD.scala
@@ -33,6 +33,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.sql.execution.datasources.v2.arrow.SparkMemoryUtils
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.util.OASPackageBridge._
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
@@ -124,6 +125,7 @@ class NativeWholeStageColumnarRDD(
       outputSchema = ConverterUtils.toArrowSchema(outputAttributes)
       resIter = transKernel.createKernelWithBatchIterator(
         inputPartition.substraitPlan, inBatchIters)
+      SparkMemoryUtils.addLeakSafeTaskCompletionListener[Unit] { _ => resIter.close() }
     }
     val iter = new Iterator[Any] {
       private val inputMetrics = TaskContext.get().taskMetrics().inputMetrics

--- a/jvm/src/test/scala/com/intel/oap/jni/TestExpressionEvaluator.java
+++ b/jvm/src/test/scala/com/intel/oap/jni/TestExpressionEvaluator.java
@@ -26,6 +26,7 @@ public class TestExpressionEvaluator {
         ExpressionEvaluator transKernel = new ExpressionEvaluator(new ArrayList<String>(),
                 "spark_columnar_jni",
                 "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-MergeTree/cmake-build-debug/utils/local-engine/liblocal_engine_jnid.so",
+                null,
                 false);
         transKernel.initNative();
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <spark.version>3.1.1</spark.version>
-    <arrow.version>7.0.0</arrow.version>
+    <arrow.version>7.0.0-gazelle</arrow.version>
     <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
     <hadoop.version>${hadoop.version}</hadoop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <spark.version>3.1.1</spark.version>
-    <arrow.version>4.0.0</arrow.version>
+    <arrow.version>7.0.0</arrow.version>
     <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
     <hadoop.version>${hadoop.version}</hadoop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -126,6 +126,7 @@
     <arrow_root>/usr/local</arrow_root>
     <build_protobuf>ON</build_protobuf>
     <build_jemalloc>ON</build_jemalloc>
+    <build_gazelle_cpp>OFF</build_gazelle_cpp>
     <project.prefix>spark-sql-columnar</project.prefix>
     <project.name.prefix>Gazelle Jni</project.name.prefix>
     <spark311.version>3.1.1</spark311.version>


### PR DESCRIPTION
Re-write the interface for the execution backend. There are two interfaces for the execution backend. One is to implement a customized backend that will parse the raw substrait plan passed down by gazelle-jni and return a result iterator, and another is to implement the customized result iterator.
The pluggable execution backend will be built into different libraries. User can choose the library to build at compile-time, and use spark conf to choose the library to load at run-time.

This PR added a dummy gazelle-cpp backend in cpp/gazelle-cpp that demonstrates how to build and run with a pluggable backend. 
- Add `-Dbuild_gazelle_cpp=ON` to the build command to build library libgazelle_cpp.so. The library will be packed into the fat jar.
e.g. `mvn clean package -P full-scala-compiler -DskipTests -Dcheckstyle.skip -Dbuild_cpp=ON -Dbuild_gazelle_cpp=ON`
- Add `--conf spark.oap.sql.columnar.backend.lib=gazelle_cpp` to spark conf, and libgazelle_cpp.so will be loaded at run-time.

Depends on: https://github.com/oap-project/arrow/pull/91.
Closes https://github.com/oap-project/gazelle-jni/issues/77.

