### PR TITLE
[GJ-90] Support ClickHouse DataSource V2 -- Phase one

### DIFF
--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -78,6 +78,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.delta</groupId>
+      <artifactId>delta-core_${scala.binary.version}</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>${arrow-memory.artifact}</artifactId>
       <version>${arrow.version}</version>
@@ -328,6 +333,9 @@
     <resources>
       <resource>
         <directory>${cpp.build.dir}</directory>
+      </resource>
+      <resource>
+        <directory>${resource.dir}</directory>
       </resource>
     </resources>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/jvm/src/main/java/com/intel/oap/substrait/rel/ExtensionTableBuilder.java
+++ b/jvm/src/main/java/com/intel/oap/substrait/rel/ExtensionTableBuilder.java
@@ -20,8 +20,9 @@ package com.intel.oap.substrait.rel;
 public class ExtensionTableBuilder {
     private ExtensionTableBuilder() {}
 
-    public static ExtensionTableNode makeExtensionTable(Integer index, String database,
-                                                    String tableName, String relativePath) {
-        return new ExtensionTableNode(index, database, tableName, relativePath);
+    public static ExtensionTableNode makeExtensionTable(Long minPartsNum, Long maxPartsNum,
+                                                        String database, String tableName,
+                                                        String relativePath) {
+        return new ExtensionTableNode(minPartsNum, maxPartsNum, database, tableName, relativePath);
     }
 }

--- a/jvm/src/main/java/com/intel/oap/substrait/rel/ExtensionTableNode.java
+++ b/jvm/src/main/java/com/intel/oap/substrait/rel/ExtensionTableNode.java
@@ -25,22 +25,25 @@ import java.io.Serializable;
 
 public class ExtensionTableNode implements Serializable {
     private static final String MERGE_TREE = "MergeTree;";
-    private Integer index;
+    private Long minPartsNum;
+    private Long maxPartsNum;
     private String database = null;
     private String tableName = null;
     private String relativePath = null;
     private StringBuffer extensionTableStr = new StringBuffer(MERGE_TREE);
 
-    ExtensionTableNode(Integer index, String database, String tableName, String relativePath) {
-        this.index = index;
+    ExtensionTableNode(Long minPartsNum, Long maxPartsNum, String database, String tableName,
+                       String relativePath) {
+        this.minPartsNum = minPartsNum;
+        this.maxPartsNum = maxPartsNum;
         this.database = database;
         this.tableName = tableName;
         this.relativePath = relativePath;
         // MergeTree;{database}\n{table}\n{relative_path}\n{min_part}\n{max_part}\n
         extensionTableStr.append(database).append("\n").append(tableName).append("\n")
                 .append(relativePath).append("\n")
-                .append((this.index + 1)).append("\n")
-                .append((this.index + 2)).append("\n");
+                .append(this.minPartsNum).append("\n")
+                .append(this.maxPartsNum).append("\n");
     }
 
     public ReadRel.ExtensionTable toProtobuf() {

--- a/jvm/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/jvm/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseDataSource

--- a/jvm/src/main/scala/com/intel/oap/GazelleJniConfig.scala
+++ b/jvm/src/main/scala/com/intel/oap/GazelleJniConfig.scala
@@ -48,7 +48,10 @@ class GazelleJniConfig(conf: SQLConf) extends Logging {
 
   // for all operators
   val enableCpu: Boolean = getCpu
-  
+
+  val enableNativeEngine: Boolean =
+    conf.getConfString("spark.oap.sql.enable.native.engine", "true").toBoolean && enableCpu
+
   // enable or disable columnar batchscan
   val enableColumnarBatchScan: Boolean =
     conf.getConfString("spark.oap.sql.columnar.batchscan", "true").toBoolean && enableCpu
@@ -213,17 +216,6 @@ class GazelleJniConfig(conf: SQLConf) extends Logging {
     }
   }
 
-  val clickhouseMergeTreeTablePath: String =
-    conf.getConfString("spark.oap.sql.columnar.ch.mergetree.table.path", "")
-
-  val clickhouseMergeTreeEnabled: Boolean =
-    conf.getConfString("spark.oap.sql.columnar.ch.mergetree.enabled", "false").toBoolean
-
-  val clickhouseMergeTreeDatabase: String =
-    conf.getConfString("spark.oap.sql.columnar.ch.mergetree.database", "default")
-
-  val clickhouseMergeTreeTable: String =
-    conf.getConfString("spark.oap.sql.columnar.ch.mergetree.table", "test")
 }
 
 object GazelleJniConfig {

--- a/jvm/src/main/scala/com/intel/oap/execution/NativeWholestageRowRDD.scala
+++ b/jvm/src/main/scala/com/intel/oap/execution/NativeWholestageRowRDD.scala
@@ -49,8 +49,9 @@ class NativeWholestageRowRDD(
     case _ => throw new SparkException(s"[BUG] Not a NativeSubstraitPartition: $split")
   }
 
-  private def castNativePartition(split: Partition): NativeFilePartition = split match {
+  private def castNativePartition(split: Partition): BaseNativeFilePartition = split match {
     case NativeSubstraitPartition(_, p: NativeFilePartition) => p
+    case NativeSubstraitPartition(_, m: NativeMergeTreePartition) => m
     case _ => throw new SparkException(s"[BUG] Not a NativeSubstraitPartition: $split")
   }
 
@@ -132,7 +133,9 @@ class NativeWholestageRowRDD(
 
       override def close(): Unit = {
         var startTime = System.nanoTime()
-        resIter.close()
+        if (resIter != null) {
+          resIter.close()
+        }
         logWarning(s"===========close ${System.nanoTime() - startTime}")
       }
     }

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseConfig.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseConfig.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse
+
+import scala.collection.JavaConverters._
+
+import java.util
+
+object ClickHouseConfig {
+
+  val NAME = "clickhouse"
+  val ALT_NAME = "clickhouse"
+  val METADATA_DIR = "_metadata_log"
+  val DEFAULT_ENGINE = "MergeTree"
+
+  /**
+   * Validates specified configurations and returns the normalized key -> value map.
+   */
+  def validateConfigurations(allProperties: util.Map[String, String]): Map[String, String] = {
+    var configurations = scala.collection.mutable.Map[String, String]()
+    allProperties.asScala.foreach(configurations += _)
+    if (!configurations.contains("metadata_path")) {
+      configurations += ("metadata_path" -> METADATA_DIR)
+    }
+    if (!configurations.contains("engine")) {
+      configurations += ("engine" -> DEFAULT_ENGINE)
+    } else {
+      val engineValue = configurations.get("engine")
+      if (!engineValue.equals(DEFAULT_ENGINE) && !engineValue.equals("parquet")) {
+        configurations += ("engine" -> DEFAULT_ENGINE)
+      }
+    }
+    if (!configurations.contains("primary_key")) {
+      configurations += ("primary_key" -> "")
+    }
+    if (!configurations.contains("sampling_key")) {
+      configurations += ("sampling_key" -> "")
+    }
+    if (!configurations.contains("storage_policy")) {
+      configurations += ("storage_policy" -> "default")
+    }
+    if (!configurations.contains("is_distribute")) {
+      configurations += ("is_distribute" -> "true")
+    }
+    configurations.toMap
+  }
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseDataSource.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseDataSource.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.connector.catalog.TableProvider
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/** A DataSource V1 for integrating Delta into Spark SQL batch and Streaming APIs. */
+class ClickHouseDataSource extends DataSourceRegister with TableProvider {
+
+  override def shortName(): String = {
+    ClickHouseConfig.NAME
+  }
+
+  def inferSchema: StructType = new StructType() // empty
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = inferSchema
+
+  override def getTable(
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: java.util.Map[String, String]): Table = {
+    val options = new CaseInsensitiveStringMap(properties)
+    val path = options.get("path")
+    if (path == null) throw DeltaErrors.pathNotSpecifiedException
+    ClickHouseTableV2(SparkSession.active, new Path(path))
+  }
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseLog.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseLog.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse
+
+import java.io.File
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTableIdentifier}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.util.{Clock, SystemClock}
+
+object ClickHouseLog {
+
+  /** Helper for creating a log when it stored at the root of the data. */
+  def forTable(spark: SparkSession, dataPath: String): DeltaLog = {
+    DeltaLog.apply(spark, new Path(dataPath, ClickHouseConfig.METADATA_DIR), new SystemClock)
+  }
+
+  /** Helper for creating a log when it stored at the root of the data. */
+  def forTable(spark: SparkSession, dataPath: File): DeltaLog = {
+    DeltaLog.apply(spark, new Path(dataPath.getAbsolutePath,
+      ClickHouseConfig.METADATA_DIR), new SystemClock)
+  }
+
+  /** Helper for creating a log when it stored at the root of the data. */
+  def forTable(spark: SparkSession, dataPath: Path): DeltaLog = {
+    DeltaLog.apply(spark, new Path(dataPath, ClickHouseConfig.METADATA_DIR), new SystemClock)
+  }
+
+  /** Helper for creating a log when it stored at the root of the data. */
+  def forTable(spark: SparkSession, dataPath: String, clock: Clock): DeltaLog = {
+    DeltaLog.apply(spark, new Path(dataPath, ClickHouseConfig.METADATA_DIR), clock)
+  }
+
+  /** Helper for creating a log when it stored at the root of the data. */
+  def forTable(spark: SparkSession, dataPath: File, clock: Clock): DeltaLog = {
+    DeltaLog.apply(spark, new Path(dataPath.getAbsolutePath, ClickHouseConfig.METADATA_DIR), clock)
+  }
+
+  /** Helper for creating a log when it stored at the root of the data. */
+  def forTable(spark: SparkSession, dataPath: Path, clock: Clock): DeltaLog = {
+    DeltaLog.apply(spark, new Path(dataPath, ClickHouseConfig.METADATA_DIR), clock)
+  }
+
+  /** Helper for creating a log for the table. */
+  def forTable(spark: SparkSession, tableName: TableIdentifier): DeltaLog = {
+    forTable(spark, tableName, new SystemClock)
+  }
+
+  /** Helper for creating a log for the table. */
+  def forTable(spark: SparkSession, table: CatalogTable): DeltaLog = {
+    forTable(spark, table, new SystemClock)
+  }
+
+  /** Helper for creating a log for the table. */
+  def forTable(spark: SparkSession, tableName: TableIdentifier, clock: Clock): DeltaLog = {
+    if (DeltaTableIdentifier.isDeltaPath(spark, tableName)) {
+      forTable(spark, new Path(tableName.table))
+    } else {
+      forTable(spark, spark.sessionState.catalog.getTableMetadata(tableName), clock)
+    }
+  }
+
+  /** Helper for creating a log for the table. */
+  def forTable(spark: SparkSession, table: CatalogTable, clock: Clock): DeltaLog = {
+    val log = DeltaLog.apply(spark, new Path(new Path(table.location),
+      ClickHouseConfig.METADATA_DIR), clock)
+    log
+  }
+
+  /** Helper for creating a log for the table. */
+  def forTable(spark: SparkSession, deltaTable: DeltaTableIdentifier): DeltaLog = {
+    if (deltaTable.path.isDefined) {
+      forTable(spark, deltaTable.path.get)
+    } else {
+      forTable(spark, deltaTable.table.get)
+    }
+  }
+
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseSparkCatalog.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseSparkCatalog.scala
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import java.util
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.catalog._
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog._
+import org.apache.spark.sql.connector.expressions.{BucketTransform, FieldReference, IdentityTransform, Transform}
+import org.apache.spark.sql.delta.commands.TableCreationModes
+import org.apache.spark.sql.delta.DeltaTableIdentifier.gluePermissionError
+import org.apache.spark.sql.execution.datasources.{DataSource, PartitioningUtils}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetSchemaConverter
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.commands.CreateClickHouseTableCommand
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.utils.{CHDataSourceUtils, ScanMergeTreePartsUtils}
+import org.apache.spark.sql.types.StructType
+
+class ClickHouseSparkCatalog extends DelegatingCatalogExtension
+  with StagingTableCatalog
+  with SupportsPathIdentifier
+  with Logging {
+
+  val spark = SparkSession.active
+
+  /**
+   * Creates a ClickHouse table
+   *
+   * @param ident The identifier of the table
+   * @param schema The schema of the table
+   * @param partitions The partition transforms for the table
+   * @param allTableProperties The table properties that configure the behavior of the table or
+   *                           provide information about the table
+   * @param writeOptions Options specific to the write during table creation or replacement
+   * @param sourceQuery A query if this CREATE request came from a CTAS or RTAS
+   * @param operation The specific table creation mode, whether this is a Create/Replace/Create or
+   *                  Replace
+   */
+  private def createClickHouseTable(
+                                     ident: Identifier,
+                                     schema: StructType,
+                                     partitions: Array[Transform],
+                                     allTableProperties: util.Map[String, String],
+                                     writeOptions: Map[String, String],
+                                     sourceQuery: Option[DataFrame],
+                                     operation: TableCreationModes.CreationMode): Table = {
+    val tableProperties = ClickHouseConfig.validateConfigurations(allTableProperties)
+    val (partitionColumns, maybeBucketSpec) = convertTransforms(partitions)
+    var newSchema = schema
+    var newPartitionColumns = partitionColumns
+    var newBucketSpec = maybeBucketSpec
+
+    val isByPath = isPathIdentifier(ident)
+    val location = if (isByPath) {
+      Option(ident.name())
+    } else {
+      Option(allTableProperties.get("location"))
+    }
+    val locUriOpt = location.map(CatalogUtils.stringToURI)
+    val storage = DataSource.buildStorageFormatFromOptions(writeOptions)
+      .copy(locationUri = locUriOpt)
+    val tableType =
+      if (location.isDefined) CatalogTableType.EXTERNAL else CatalogTableType.MANAGED
+    val id = TableIdentifier(ident.name(), ident.namespace().lastOption)
+    val loc = new Path(locUriOpt.getOrElse(spark.sessionState.catalog.defaultTablePath(id)))
+    val commentOpt = Option(allTableProperties.get("comment"))
+
+    val tableDesc = new CatalogTable(
+      identifier = id,
+      tableType = tableType,
+      storage = storage,
+      schema = newSchema,
+      provider = Some(ClickHouseConfig.ALT_NAME),
+      partitionColumnNames = newPartitionColumns,
+      bucketSpec = newBucketSpec,
+      properties = tableProperties,
+      comment = commentOpt)
+
+    val withDb = verifyTableAndSolidify(tableDesc, None)
+    ParquetSchemaConverter.checkFieldNames(tableDesc.schema.fieldNames)
+
+    // TODO: Generate WriteClickHouseTableCommand
+    // val writer = sourceQuery.map { df =>
+    // }
+
+    CreateClickHouseTableCommand(
+      withDb,
+      getExistingTableIfExists(tableDesc),
+      operation.mode,
+      operation = operation,
+      tableByPath = isByPath).run(spark)
+
+    logInfo(s"create table ${ident.toString} successfully.")
+    val loadedNewTable = loadTable(ident)
+    logInfo(s"scanning table ${ident.toString} data ...")
+    loadedNewTable match {
+      case v: ClickHouseTableV2 => {
+        // TODO: remove this operation after implementing write mergetree into table
+        ScanMergeTreePartsUtils.scanMergeTreePartsToAddFile(spark.sessionState.newHadoopConf(), v)
+        v.refresh()
+      }
+      case _ =>
+    }
+    loadedNewTable
+  }
+
+  override def createTable(ident: Identifier, schema: StructType, partitions: Array[Transform],
+                           properties: util.Map[String, String]): Table = {
+    if (CHDataSourceUtils.isClickHouseDataSourceName(getProvider(properties))) {
+      createClickHouseTable(
+        ident,
+        schema,
+        partitions,
+        properties,
+        Map.empty,
+        sourceQuery = None,
+        TableCreationModes.Create)
+    } else {
+      super.createTable(ident, schema, partitions, properties)
+    }
+  }
+
+  // Copy of V2SessionCatalog.convertTransforms, which is private.
+  private def convertTransforms(partitions: Seq[Transform]): (Seq[String], Option[BucketSpec]) = {
+    val identityCols = new mutable.ArrayBuffer[String]
+    var bucketSpec = Option.empty[BucketSpec]
+
+    partitions.map {
+      case IdentityTransform(FieldReference(Seq(col))) =>
+        identityCols += col
+
+
+      case BucketTransform(numBuckets, FieldReference(Seq(col))) =>
+        bucketSpec = Some(BucketSpec(numBuckets, col :: Nil, Nil))
+
+      case transform =>
+        throw new UnsupportedOperationException(s"Partitioning by expressions")
+    }
+
+    (identityCols, bucketSpec)
+  }
+
+  private def newDeltaPathTable(ident: Identifier): ClickHouseTableV2 = {
+    ClickHouseTableV2(spark, new Path(ident.name()))
+  }
+
+  override def loadTable(ident: Identifier): Table = {
+    try {
+      super.loadTable(ident) match {
+        case v1: V1Table if CHDataSourceUtils.isDeltaTable(v1.catalogTable) =>
+          ClickHouseTableV2(
+            spark,
+            new Path(v1.catalogTable.location),
+            catalogTable = Some(v1.catalogTable),
+            tableIdentifier = Some(ident.toString))
+        case o => o
+      }
+    } catch {
+      case _: NoSuchDatabaseException | _: NoSuchNamespaceException | _: NoSuchTableException
+        if isPathIdentifier(ident) =>
+        newDeltaPathTable(ident)
+      case e: AnalysisException if gluePermissionError(e) && isPathIdentifier(ident) =>
+        logWarning("Received an access denied error from Glue. Assuming this " +
+          s"identifier ($ident) is path based.", e)
+        newDeltaPathTable(ident)
+    }
+  }
+
+
+  override def invalidateTable(ident: Identifier): Unit = {
+    try {
+      loadTable(ident) match {
+        case v: ClickHouseTableV2 => {
+          ScanMergeTreePartsUtils.scanMergeTreePartsToAddFile(spark.sessionState.newHadoopConf(),
+            v)
+          v.refresh()
+        }
+      }
+      super.invalidateTable(ident)
+    }
+    catch {
+      case ignored: NoSuchTableException =>
+      // ignore if the table doesn't exist, it is not cached
+    }
+  }
+
+  override def stageCreate(ident: Identifier, schema: StructType, partitions: Array[Transform],
+                           properties: util.Map[String, String]): StagedTable = {
+    throw new UnsupportedOperationException("Do not support stageCreate currently.")
+  }
+
+  override def stageReplace(ident: Identifier, schema: StructType, partitions: Array[Transform],
+                            properties: util.Map[String, String]): StagedTable = {
+    throw new UnsupportedOperationException("Do not support stageReplace currently.")
+  }
+
+  override def stageCreateOrReplace(ident: Identifier, schema: StructType,
+                                    partitions: Array[Transform],
+                                    properties: util.Map[String, String]): StagedTable = {
+    throw new UnsupportedOperationException("Do not support stageCreateOrReplace currently.")
+  }
+
+  /** Performs checks on the parameters provided for table creation for a ClickHouse table. */
+  private def verifyTableAndSolidify(
+                                      tableDesc: CatalogTable,
+                                      query: Option[LogicalPlan]): CatalogTable = {
+
+    if (tableDesc.bucketSpec.isDefined) {
+      throw new UnsupportedOperationException("Do not support Bucketing")
+    }
+
+    val schema = query.map { plan =>
+      assert(tableDesc.schema.isEmpty, "Can't specify table schema in CTAS.")
+      plan.schema.asNullable
+    }.getOrElse(tableDesc.schema)
+
+    PartitioningUtils.validatePartitionColumn(
+      schema,
+      tableDesc.partitionColumnNames,
+      caseSensitive = false) // Delta is case insensitive
+
+    val db = tableDesc.identifier.database.getOrElse(catalog.getCurrentDatabase)
+    val tableIdentWithDB = tableDesc.identifier.copy(database = Some(db))
+    tableDesc.copy(
+      identifier = tableIdentWithDB,
+      schema = schema,
+      properties = tableDesc.properties)
+  }
+
+
+  /** Checks if a table already exists for the provided identifier. */
+  private def getExistingTableIfExists(table: CatalogTable): Option[CatalogTable] = {
+    // If this is a path identifier, we cannot return an existing CatalogTable. The Create command
+    // will check the file system itself
+    if (isPathIdentifier(table)) return None
+    val tableExists = catalog.tableExists(table.identifier)
+    if (tableExists) {
+      val oldTable = catalog.getTableMetadata(table.identifier)
+      if (oldTable.tableType == CatalogTableType.VIEW) {
+        throw new AnalysisException(
+          s"${table.identifier} is a view. You may not write data into a view.")
+      }
+      if (!CHDataSourceUtils.isClickHouseTable(oldTable.provider)) {
+        throw new AnalysisException(s"${table.identifier} is not a ClickHouse table. Please drop " +
+          s"this table first if you would like to recreate it.")
+      }
+      Some(oldTable)
+    } else {
+      None
+    }
+  }
+
+  private def getProvider(properties: util.Map[String, String]): String = {
+    Option(properties.get("provider")).getOrElse(ClickHouseConfig.NAME)
+  }
+}
+
+/**
+ * A trait for handling table access through clickhouse.`/some/path`. This is a stop-gap solution
+ * until PathIdentifiers are implemented in Apache Spark.
+ */
+trait SupportsPathIdentifier extends TableCatalog { self: ClickHouseSparkCatalog =>
+
+  private def supportSQLOnFile: Boolean = spark.sessionState.conf.runSQLonFile
+
+  protected lazy val catalog: SessionCatalog = spark.sessionState.catalog
+
+  private def hasClickHouseNamespace(ident: Identifier): Boolean = {
+    ident.namespace().length == 1 &&
+      CHDataSourceUtils.isClickHouseDataSourceName(ident.namespace().head)
+  }
+
+  protected def isPathIdentifier(ident: Identifier): Boolean = {
+    // Should be a simple check of a special PathIdentifier class in the future
+    try {
+      supportSQLOnFile && hasClickHouseNamespace(ident) && new Path(ident.name()).isAbsolute
+    } catch {
+      case _: IllegalArgumentException => false
+    }
+  }
+
+  protected def isPathIdentifier(table: CatalogTable): Boolean = {
+    isPathIdentifier(Identifier.of(table.identifier.database.toArray, table.identifier.table))
+  }
+
+  override def tableExists(ident: Identifier): Boolean = {
+    if (isPathIdentifier(ident)) {
+      val path = new Path(ident.name())
+      val fs = path.getFileSystem(spark.sessionState.newHadoopConf())
+      fs.exists(path) && fs.listStatus(path).nonEmpty
+    } else {
+      super.tableExists(ident)
+    }
+  }
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/commands/CreateClickHouseTableCommand.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/commands/CreateClickHouseTableCommand.scala
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.commands
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.commands.TableCreationModes
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaOperations, DeltaOptions, OptimisticTransaction, Snapshot}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseLog
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ */
+case class CreateClickHouseTableCommand(
+    table: CatalogTable,
+    existingTableOpt: Option[CatalogTable],
+    mode: SaveMode,
+    query: Option[LogicalPlan] = None,
+    operation: TableCreationModes.CreationMode = TableCreationModes.Create,
+    tableByPath: Boolean = false,
+    override val output: Seq[Attribute] = Nil)
+  extends RunnableCommand
+  with DeltaLogging {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    assert(table.tableType != CatalogTableType.VIEW)
+    assert(table.identifier.database.isDefined, "Database should've been fixed at analysis")
+    // There is a subtle race condition here, where the table can be created by someone else
+    // while this command is running. Nothing we can do about that though :(
+    val tableExists = existingTableOpt.isDefined
+    if (mode == SaveMode.Ignore && tableExists) {
+      // Early exit on ignore
+      return Nil
+    } else if (mode == SaveMode.ErrorIfExists && tableExists) {
+      throw new AnalysisException(s"Table ${table.identifier.quotedString} already exists.")
+    }
+
+    val tableWithLocation = if (tableExists) {
+      val existingTable = existingTableOpt.get
+      table.storage.locationUri match {
+        case Some(location) if location.getPath != existingTable.location.getPath =>
+          val tableName = table.identifier.quotedString
+          throw new AnalysisException(
+            s"The location of the existing table $tableName is " +
+              s"`${existingTable.location}`. It doesn't match the specified location " +
+              s"`${table.location}`.")
+        case _ =>
+      }
+      table.copy(
+        storage = existingTable.storage,
+        tableType = existingTable.tableType)
+    } else if (table.storage.locationUri.isEmpty) {
+      // We are defining a new managed table
+      assert(table.tableType == CatalogTableType.MANAGED)
+      val loc = sparkSession.sessionState.catalog.defaultTablePath(table.identifier)
+      table.copy(storage = table.storage.copy(locationUri = Some(loc)))
+    } else {
+      // We are defining a new external table
+      assert(table.tableType == CatalogTableType.EXTERNAL)
+      table
+    }
+
+    val isManagedTable = tableWithLocation.tableType == CatalogTableType.MANAGED
+    val tableLocation = new Path(tableWithLocation.location)
+    val fs = tableLocation.getFileSystem(sparkSession.sessionState.newHadoopConf())
+    val deltaLog = ClickHouseLog.forTable(sparkSession, tableLocation)
+    val options = new DeltaOptions(table.storage.properties, sparkSession.sessionState.conf)
+    var result: Seq[Row] = Nil
+
+    recordDeltaOperation(deltaLog, "delta.ddl.createTable") {
+      val txn = deltaLog.startTransaction()
+      if (query.isDefined) {
+        // TODO: implement writing clickhouse data
+        Seq.empty[Row]
+      } else {
+        def createTransactionLogOrVerify(): Unit = {
+          if (isManagedTable) {
+            // When creating a managed table, the table path should not exist or is empty, or
+            // users would be surprised to see the data, or see the data directory being dropped
+            // after the table is dropped.
+            // assertPathEmpty(sparkSession, tableWithLocation)
+          }
+
+          // This is either a new table, or, we never defined the schema of the table. While it is
+          // unexpected that `txn.metadata.schema` to be empty when txn.readVersion >= 0, we still
+          // guard against it, in case of checkpoint corruption bugs.
+          val noExistingMetadata = txn.readVersion == -1 || txn.metadata.schema.isEmpty
+          if (noExistingMetadata) {
+            assertTableSchemaDefined(fs, tableLocation, tableWithLocation, sparkSession)
+            // assertPathEmpty(sparkSession, tableWithLocation)
+            // This is a user provided schema.
+            // Doesn't come from a query, Follow nullability invariants.
+            val newMetadata = getProvidedMetadata(table, table.schema.json)
+            txn.updateMetadataForNewTable(newMetadata)
+
+            val op = getOperation(newMetadata, isManagedTable, None)
+            txn.commit(Nil, op)
+          } else {
+            val newProperties = DeltaConfigs.mergeGlobalConfigs(sparkSession.sessionState.conf,
+              tableWithLocation.properties)
+            verifyTableMetadata(txn, tableWithLocation, newProperties)
+          }
+        }
+        // We are defining a table using the Create or Replace Table statements.
+        operation match {
+          case TableCreationModes.Create =>
+            require(!tableExists, "Can't recreate a table when it exists")
+            createTransactionLogOrVerify()
+
+          case TableCreationModes.CreateOrReplace if !tableExists =>
+            // If the table doesn't exist, CREATE OR REPLACE must provide a schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            createTransactionLogOrVerify()
+          case _ =>
+            // TODO:
+        }
+      }
+
+      // We would have failed earlier on if we couldn't ignore the existence of the table
+      // In addition, we just might using saveAsTable to append to the table, so ignore the creation
+      // if it already exists.
+      // Note that someone may have dropped and recreated the table in a separate location in the
+      // meantime... Unfortunately we can't do anything there at the moment, because Hive sucks.
+      logInfo(s"Table is path-based table: $tableByPath. Update catalog with mode: $operation")
+      updateCatalog(sparkSession, tableWithLocation, deltaLog.snapshot, txn)
+
+      result
+    }
+  }
+
+  private def getProvidedMetadata(table: CatalogTable, schemaString: String): Metadata = {
+    Metadata(
+      format = Format(table.properties.get("engine").get),
+      description = table.comment.orNull,
+      schemaString = schemaString,
+      partitionColumns = table.partitionColumnNames,
+      configuration = table.properties)
+  }
+
+  private def assertPathEmpty(
+      sparkSession: SparkSession,
+      tableWithLocation: CatalogTable): Unit = {
+    val path = new Path(tableWithLocation.location)
+    val fs = path.getFileSystem(sparkSession.sessionState.newHadoopConf())
+    // Verify that the table location associated with CREATE TABLE doesn't have any data. Note that
+    // we intentionally diverge from this behavior w.r.t regular datasource tables (that silently
+    // overwrite any previous data)
+    if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      throw new AnalysisException(s"Cannot create table ('${tableWithLocation.identifier}')." +
+        s" The associated location ('${tableWithLocation.location}') is not empty but " +
+        s"it's not a ClickHouse table")
+    }
+  }
+
+  private def assertTableSchemaDefined(
+      fs: FileSystem,
+      path: Path,
+      table: CatalogTable,
+      sparkSession: SparkSession): Unit = {
+    // Users did not specify the schema. We expect the schema exists in Delta.
+    if (table.schema.isEmpty) {
+      if (table.tableType == CatalogTableType.EXTERNAL) {
+        if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+          throw DeltaErrors.createExternalTableWithoutLogException(
+            path, table.identifier.quotedString, sparkSession)
+        } else {
+          throw DeltaErrors.createExternalTableWithoutSchemaException(
+            path, table.identifier.quotedString, sparkSession)
+        }
+      } else {
+        throw DeltaErrors.createManagedTableWithoutSchemaException(
+          table.identifier.quotedString, sparkSession)
+      }
+    }
+  }
+
+  /**
+   * Verify against our transaction metadata that the user specified the right metadata for the
+   * table.
+   */
+  private def verifyTableMetadata(
+                                   txn: OptimisticTransaction,
+                                   tableDesc: CatalogTable,
+                                   properties: Map[String, String]): Unit = {
+    val existingMetadata = txn.metadata
+    val path = new Path(tableDesc.location)
+
+    // The delta log already exists. If they give any configuration, we'll make sure it all matches.
+    // Otherwise we'll just go with the metadata already present in the log.
+    // The schema compatibility checks will be made in `WriteIntoDelta` for CreateTable
+    // with a query
+    if (txn.readVersion > -1) {
+      if (tableDesc.schema.nonEmpty) {
+        // We check exact alignment on create table if everything is provided
+        val differences = SchemaUtils.reportDifferences(existingMetadata.schema, tableDesc.schema)
+        if (differences.nonEmpty) {
+          throw DeltaErrors.createTableWithDifferentSchemaException(
+            path, tableDesc.schema, existingMetadata.schema, differences)
+        }
+      }
+
+      // If schema is specified, we must make sure the partitioning matches, even the partitioning
+      // is not specified.
+      if (tableDesc.schema.nonEmpty &&
+        tableDesc.partitionColumnNames != existingMetadata.partitionColumns) {
+        throw DeltaErrors.createTableWithDifferentPartitioningException(
+          path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
+      }
+
+      if (properties.nonEmpty && properties != existingMetadata.configuration) {
+        throw DeltaErrors.createTableWithDifferentPropertiesException(
+          path, tableDesc.properties, existingMetadata.configuration)
+      }
+    }
+  }
+
+  /**
+   * Based on the table creation operation, and parameters, we can resolve to different operations.
+   * A lot of this is needed for legacy reasons in Databricks Runtime.
+   * @param metadata The table metadata, which we are creating or replacing
+   * @param isManagedTable Whether we are creating or replacing a managed table
+   * @param options Write options, if this was a CTAS/RTAS
+   */
+  private def getOperation(
+      metadata: Metadata,
+      isManagedTable: Boolean,
+      options: Option[DeltaOptions]): DeltaOperations.Operation = operation match {
+    // This is legacy saveAsTable behavior in Databricks Runtime
+    case TableCreationModes.Create if existingTableOpt.isDefined && query.isDefined =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere)
+
+    // DataSourceV2 table creation
+    case TableCreationModes.Create =>
+      DeltaOperations.CreateTable(metadata, isManagedTable, query.isDefined)
+
+    // DataSourceV2 table replace
+    case TableCreationModes.Replace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = false, query.isDefined)
+
+    // Legacy saveAsTable with Overwrite mode
+    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere)
+
+    // New DataSourceV2 saveAsTable with overwrite mode behavior
+    case TableCreationModes.CreateOrReplace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = true, query.isDefined)
+  }
+
+  /**
+   * Similar to getOperation, here we disambiguate the catalog alterations we need to do based
+   * on the table operation, and whether we have reached here through legacy code or DataSourceV2
+   * code paths.
+   */
+  private def updateCatalog(
+                             spark: SparkSession,
+                             table: CatalogTable,
+                             snapshot: Snapshot,
+                             txn: OptimisticTransaction): Unit = {
+    val cleaned = cleanupTableDefinition(table, snapshot)
+    operation match {
+      case _ if tableByPath => // do nothing with the metastore if this is by path
+      case TableCreationModes.Create =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = existingTableOpt.isDefined,
+          validateLocation = false)
+      case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
+          if existingTableOpt.isDefined =>
+        spark.sessionState.catalog.alterTable(table)
+      case TableCreationModes.Replace =>
+        val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
+        throw new CannotReplaceMissingTableException(ident)
+      case TableCreationModes.CreateOrReplace =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = false,
+          validateLocation = false)
+    }
+  }
+
+  /** Clean up the information we pass on to store in the catalog. */
+  private def cleanupTableDefinition(table: CatalogTable, snapshot: Snapshot): CatalogTable = {
+    // These actually have no effect on the usability of Delta, but feature flagging legacy
+    // behavior for now
+    val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+      // Legacy behavior
+      table.storage
+    } else {
+      table.storage.copy(properties = Map.empty)
+    }
+
+    table.copy(
+      schema = new StructType(),
+      properties = Map.empty,
+      partitionColumnNames = Nil,
+      // Remove write specific options when updating the catalog
+      storage = storageProps,
+      tracksPartitionsInCatalog = true)
+  }
+
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.metadata
+
+import org.apache.spark.sql.delta.actions.AddFile
+
+case class AddMergeTreeParts(database: String, table: String, engine: String,
+                             path: String, targetNode: String,
+                             name: String, uuid: String,
+                             rows: Long, bytesOnDisk: Long,
+                             dataCompressedBytes: Long, dataUncompressedBytes: Long,
+                             modificationTime: Long, partitionId: String,
+                             minBlockNumber: Long, maxBlockNumber: Long,
+                             level: Int, dataVersion: Long, dataChange: Boolean,
+                             partition: String = "",
+                             defaultCompressionCodec: String = "LZ4", stats: String = "",
+                             partitionValues: Map[String, String] = Map.empty[String, String],
+                             partType: String = "Wide", active: Int = 1,
+                             marks: Long = -1L, marksBytes: Long = -1L,
+                             removeTime: Long = -1L, refcount: Int = -1,
+                             minDate: Int = -1, maxDate: Int = -1,
+                             minTime: Long = -1L, maxTime: Long = -1L,
+                             primaryKeyBytesInMemory: Long = -1L,
+                             primaryKeyBytesInMemoryAllocated: Long = -1L,
+                             isFrozen: Int = 0, diskName: String = "default",
+                             hashOfAllFiles: String = "", hashOfUncompressedFiles: String = "",
+                             uncompressedHashOfCompressedFiles: String = "",
+                             deleteTtlInfoMin: Long = -1L, deleteTtlInfoMax: Long = -1L,
+                             moveTtlInfoExpression: String = "",
+                             moveTtlInfoMin: Long = -1L, moveTtlInfoMax: Long = -1L,
+                             recompressionTtlInfoExpression: String = "",
+                             recompressionTtlInfoMin: Long = -1L,
+                             recompressionTtlInfoMax: Long = -1L,
+                             groupByTtlInfoExpression: String = "",
+                             groupByTtlInfoMin: Long = -1L, groupByTtlInfoMax: Long = -1L,
+                             rowsWhereTtlInfoExpression: String = "",
+                             rowsWhereTtlInfoMin: Long = -1L, rowsWhereTtlInfoMax: Long = -1L
+                            )
+
+object AddFileTags {
+
+  def partsInfoToAddFile(database: String, table: String, engine: String,
+                         path: String, targetNode: String,
+                         name: String, uuid: String,
+                         rows: Long, bytesOnDisk: Long,
+                         dataCompressedBytes: Long, dataUncompressedBytes: Long,
+                         modificationTime: Long, partitionId: String,
+                         minBlockNumber: Long, maxBlockNumber: Long,
+                         level: Int, dataVersion: Long, dataChange: Boolean,
+                         partition: String = "",
+                         defaultCompressionCodec: String = "LZ4",
+                         stats: String = "",
+                         partitionValues: Map[String, String] = Map.empty[String, String]): AddFile = {
+    val tags = Map[String, String]("database" -> database, "table" -> table, "engine" -> engine,
+      "path" -> path, "targetNode" -> targetNode, "partition" -> partition,
+      "uuid" -> uuid, "rows" -> rows.toString, "bytesOnDisk" -> bytesOnDisk.toString,
+      "dataCompressedBytes" -> dataCompressedBytes.toString,
+      "dataUncompressedBytes" -> dataUncompressedBytes.toString,
+      "modificationTime" -> modificationTime.toString,
+      "partitionId" -> partitionId,
+      "minBlockNumber" -> minBlockNumber.toString,
+      "maxBlockNumber" -> maxBlockNumber.toString, "level" -> level.toString,
+      "dataVersion" -> dataVersion.toString,
+      "defaultCompressionCodec" -> defaultCompressionCodec)
+    AddFile(name, partitionValues, bytesOnDisk, modificationTime, dataChange, stats, tags)
+  }
+
+  def partsMapToParts(addFile: AddFile): AddMergeTreeParts = {
+    assert(addFile.tags != null && !addFile.tags.isEmpty)
+    AddMergeTreeParts(addFile.tags.get("database").get, addFile.tags.get("table").get,
+      addFile.tags.get("engine").get, addFile.tags.get("path").get,
+      addFile.tags.get("targetNode").get, addFile.path, addFile.tags.get("uuid").get,
+      addFile.tags.get("rows").get.toLong, addFile.size,
+      addFile.tags.get("dataCompressedBytes").get.toLong,
+      addFile.tags.get("dataUncompressedBytes").get.toLong,
+      addFile.modificationTime, addFile.tags.get("partitionId").get,
+      addFile.tags.get("minBlockNumber").get.toLong, addFile.tags.get("maxBlockNumber").get.toLong,
+      addFile.tags.get("level").get.toInt, addFile.tags.get("dataVersion").get.toLong,
+      addFile.dataChange, addFile.tags.get("partition").get,
+      addFile.tags.get("defaultCompressionCodec").get, addFile.stats,
+      addFile.partitionValues
+    )
+  }
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHousePartitionReaderFactory.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHousePartitionReaderFactory.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+
+class ClickHousePartitionReaderFactory extends PartitionReaderFactory with Logging {
+
+  override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    null
+  }
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseScan.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseScan.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
+
+import java.util.OptionalLong
+
+import scala.collection.mutable.ArrayBuffer
+
+import com.intel.oap.execution.NativeMergeTreePartition
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.connector.read._
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.metadata.AddMergeTreeParts
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+case class ClickHouseScan(
+                           sparkSession: SparkSession,
+                           @transient table: ClickHouseTableV2,
+                           dataSchema: StructType,
+                           readDataSchema: StructType,
+                           pushedFilters: Array[Filter],
+                           options: CaseInsensitiveStringMap,
+                           partitionFilters: Seq[Expression] = Seq.empty,
+                           dataFilters: Seq[Expression] = Seq.empty) extends FileScan {
+
+  override def isSplitable(path: Path): Boolean = false
+
+  override def readPartitionSchema: StructType = new StructType()
+
+  override def fileIndex: PartitioningAwareFileIndex = null
+
+  override def withFilters(partitionFilters: Seq[Expression],
+                           dataFilters: Seq[Expression]): FileScan =
+    this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+
+  override def toBatch: Batch = this
+
+  protected def getSnapshot(): Snapshot = table.updateSnapshot()
+
+  def getPartsPartitions(
+                          sparkSession: SparkSession,
+                          partsFiles: Seq[AddMergeTreeParts],
+                          maxSplitBytes: Long): Seq[InputPartition] = {
+    val partitions = new ArrayBuffer[InputPartition]
+    val database = table.catalogTable.get.identifier.database.get
+    val tableName = table.catalogTable.get.identifier.table
+    val engine = table.snapshot.metadata.configuration.get("engine").get
+    val tablePath = table.deltaLog.dataPath.toString.substring(6)
+    var currentMinPartsNum = -1L
+    var currentMaxPartsNum = -1L
+    var currentSize = 0L
+
+    /** Close the current partition and move to the next. */
+    def closePartition(): Unit = {
+      if (currentMinPartsNum > 0L && currentMaxPartsNum >= currentMinPartsNum) {
+        val newPartition = NativeMergeTreePartition(partitions.size, engine, database, tableName,
+          tablePath, currentMinPartsNum, currentMaxPartsNum + 1)
+        partitions += newPartition
+      }
+      currentMinPartsNum = -1L
+      currentMaxPartsNum = -1L
+      currentSize = 0
+    }
+
+    val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
+    // Assign files to partitions using "Next Fit Decreasing"
+    partsFiles.foreach { parts =>
+      if (currentSize + parts.bytesOnDisk > maxSplitBytes) {
+        closePartition()
+      }
+      // Add the given file to the current partition.
+      currentSize += parts.bytesOnDisk + openCostInBytes
+      if (currentMinPartsNum == -1L) {
+        currentMinPartsNum = parts.minBlockNumber
+      }
+      currentMaxPartsNum = parts.maxBlockNumber
+    }
+    closePartition()
+    partitions.toSeq
+  }
+
+  protected def partsPartitions: Seq[InputPartition] = {
+    val defaultMaxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
+    val allParts = table.listFiles()
+    getPartsPartitions(sparkSession, allParts, defaultMaxSplitBytes)
+  }
+
+  override def planInputPartitions(): Array[InputPartition] = partsPartitions.toArray
+
+  override def createReaderFactory(): PartitionReaderFactory = {
+    new ClickHousePartitionReaderFactory()
+  }
+
+  override def estimateStatistics(): Statistics = {
+    new Statistics {
+      override def sizeInBytes(): OptionalLong = OptionalLong.empty()
+
+      override def numRows(): OptionalLong = OptionalLong.empty()
+    }
+  }
+
+  override def getMetaData(): Map[String, String] = {
+    Map.empty[String, String]
+  }
+
+  override def equals(obj: Any): Boolean = obj match {
+    case p: ClickHouseScan =>
+      super.equals(p) && dataSchema == p.dataSchema && options == p.options &&
+        equivalentFilters(pushedFilters, p.pushedFilters)
+    case _ => false
+  }
+
+  override def hashCode(): Int = getClass.hashCode()
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseScanBuilder.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseScanBuilder.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, SparkToParquetSchemaConverter}
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class ClickHouseScanBuilder(
+                             sparkSession: SparkSession,
+                             table: ClickHouseTableV2,
+                             tableSchema: StructType,
+                             options: CaseInsensitiveStringMap
+                           )
+  extends ScanBuilder with SupportsPushDownFilters with SupportsPushDownRequiredColumns {
+
+  private val isCaseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
+  protected val supportsNestedSchemaPruning = true
+  protected var requiredSchema = StructType(tableSchema.fields)
+
+  lazy val hadoopConf = {
+    val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
+    // Hadoop Configurations are case sensitive.
+    sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap)
+  }
+
+  lazy val pushedParquetFilters = {
+    val sqlConf = sparkSession.sessionState.conf
+    val pushDownDate = sqlConf.parquetFilterPushDownDate
+    val pushDownTimestamp = sqlConf.parquetFilterPushDownTimestamp
+    val pushDownDecimal = sqlConf.parquetFilterPushDownDecimal
+    val pushDownStringStartWith = sqlConf.parquetFilterPushDownStringStartWith
+    val pushDownInFilterThreshold = sqlConf.parquetFilterPushDownInFilterThreshold
+    val isCaseSensitive = sqlConf.caseSensitiveAnalysis
+    val parquetSchema =
+      new SparkToParquetSchemaConverter(sparkSession.sessionState.conf).convert(tableSchema)
+    val parquetFilters = new ParquetFilters(parquetSchema, pushDownDate, pushDownTimestamp,
+      pushDownDecimal, pushDownStringStartWith, pushDownInFilterThreshold, isCaseSensitive)
+    parquetFilters.convertibleFilters(this.filters).toArray
+  }
+
+  private var filters: Array[Filter] = Array.empty
+
+  override def build(): Scan = {
+    new ClickHouseScan(sparkSession, table, tableSchema, readDataSchema(),
+      pushedParquetFilters, options)
+  }
+
+  override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+    this.filters = filters
+    this.filters
+  }
+
+  override def pushedFilters(): Array[Filter] = pushedParquetFilters
+
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    this.requiredSchema = requiredSchema
+  }
+
+  protected def readDataSchema(): StructType = {
+    val requiredNameSet = createRequiredNameSet()
+    val schema = if (supportsNestedSchemaPruning) requiredSchema else tableSchema
+    val fields = schema.fields.filter { field =>
+      val colName = PartitioningUtils.getColName(field, isCaseSensitive)
+      requiredNameSet.contains(colName)
+    }
+    StructType(fields)
+  }
+
+  private def createRequiredNameSet(): Set[String] =
+    requiredSchema.fields.map(PartitioningUtils.getColName(_, isCaseSensitive)).toSet
+
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/table/ClickHouseTableV2.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/table/ClickHouseTableV2.scala
@@ -1,0 +1,239 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.table
+
+import java.util.concurrent.TimeUnit
+
+import java.{util => ju}
+import org.sparkproject.guava.cache.{CacheBuilder, CacheLoader}
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.delta.actions.{AddFile, SingleAction}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.{ClickHouseConfig, ClickHouseLog}
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.metadata.{AddFileTags, AddMergeTreeParts}
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.source.ClickHouseScanBuilder
+
+// scalastyle:off import.ordering.noEmptyLine
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils}
+import org.apache.spark.sql.connector.catalog._
+import org.apache.spark.sql.connector.catalog.TableCapability._
+import org.apache.spark.sql.connector.expressions._
+import org.apache.spark.sql.connector.write._
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, DeltaTableUtils, DeltaTimeTravelSpec, GeneratedColumn, Snapshot}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaDataSource
+import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * The data source V2 representation of a ClickHouse table that exists.
+ *
+ * @param path The path to the table
+ * @param tableIdentifier The table identifier for this table
+ */
+case class ClickHouseTableV2(
+    spark: SparkSession,
+    path: Path,
+    catalogTable: Option[CatalogTable] = None,
+    tableIdentifier: Option[String] = None,
+    timeTravelOpt: Option[DeltaTimeTravelSpec] = None,
+    options: CaseInsensitiveStringMap = CaseInsensitiveStringMap.empty())
+  extends Table
+  with SupportsWrite
+  with SupportsRead
+  with DeltaLogging {
+
+  private lazy val (rootPath, partitionFilters, timeTravelByPath) = {
+    if (catalogTable.isDefined) {
+      // Fast path for reducing path munging overhead
+      (new Path(catalogTable.get.location), Nil, None)
+    } else {
+      DeltaDataSource.parsePathIdentifier(spark, path.toString)
+    }
+  }
+
+  // The loading of the DeltaLog is lazy in order to reduce the amount of FileSystem calls,
+  // in cases where we will fallback to the V1 behavior.
+  lazy val deltaLog: DeltaLog = ClickHouseLog.forTable(spark, rootPath)
+
+  def updateSnapshot(forceUpdate: Boolean = false): Snapshot = {
+    val needToUpdate = forceUpdate || ClickHouseTableV2.isSnapshotStale
+    if (needToUpdate) {
+      val snapshotUpdated = deltaLog.update()
+      ClickHouseTableV2.fileStatusCache.invalidate(this.rootPath)
+      ClickHouseTableV2.lastUpdateTimestamp = System.currentTimeMillis()
+      snapshotUpdated
+    } else {
+      deltaLog.snapshot
+    }
+  }
+
+  def getTableIdentifierIfExists: Option[TableIdentifier] = tableIdentifier.map(
+    spark.sessionState.sqlParser.parseTableIdentifier)
+
+  override def name(): String = catalogTable.map(_.identifier.unquotedString)
+    .orElse(tableIdentifier)
+    .getOrElse(s"clickhouse.`${deltaLog.dataPath}`")
+
+  private lazy val timeTravelSpec: Option[DeltaTimeTravelSpec] = {
+    if (timeTravelOpt.isDefined && timeTravelByPath.isDefined) {
+      throw DeltaErrors.multipleTimeTravelSyntaxUsed
+    }
+    timeTravelOpt.orElse(timeTravelByPath)
+  }
+
+  lazy val snapshot: Snapshot = {
+    timeTravelSpec.map { spec =>
+      val (version, accessType) = DeltaTableUtils.resolveTimeTravelVersion(
+        spark.sessionState.conf, deltaLog, spec)
+      val source = spec.creationSource.getOrElse("unknown")
+      recordDeltaEvent(deltaLog, s"delta.timeTravel.$source", data = Map(
+        "tableVersion" -> deltaLog.snapshot.version,
+        "queriedVersion" -> version,
+        "accessType" -> accessType
+      ))
+      deltaLog.getSnapshotAt(version)
+    }.getOrElse(updateSnapshot())
+  }
+
+  private lazy val tableSchema: StructType =
+    GeneratedColumn.removeGenerationExpressions(snapshot.schema)
+
+  override def schema(): StructType = tableSchema
+
+  override def partitioning(): Array[Transform] = {
+    snapshot.metadata.partitionColumns.map { col =>
+      new IdentityTransform(new FieldReference(Seq(col)))
+    }.toArray
+  }
+
+  override def properties(): ju.Map[String, String] = {
+    val base = snapshot.getProperties
+    base.put(TableCatalog.PROP_PROVIDER, ClickHouseConfig.NAME)
+    base.put(TableCatalog.PROP_LOCATION, CatalogUtils.URIToString(path.toUri))
+    Option(snapshot.metadata.description).foreach(base.put(TableCatalog.PROP_COMMENT, _))
+    // this reports whether the table is an external or managed catalog table as
+    // the old DescribeTable command would
+    catalogTable.foreach(table => base.put("Type", table.tableType.name))
+    base.asJava
+  }
+
+  override def capabilities(): ju.Set[TableCapability] = Set(
+    ACCEPT_ANY_SCHEMA, BATCH_READ,
+    BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE
+  ).asJava
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    throw new UnsupportedOperationException("Do not support write data now.")
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    new ClickHouseScanBuilder(spark, this, tableSchema, options)
+  }
+
+  /**
+   * Creates a V1 BaseRelation from this Table to allow read APIs to go through V1 DataSource code
+   * paths.
+   */
+  def toBaseRelation: BaseRelation = {
+    if (!deltaLog.tableExists) {
+      val id = catalogTable.map(ct => DeltaTableIdentifier(table = Some(ct.identifier)))
+        .getOrElse(DeltaTableIdentifier(path = Some(path.toString)))
+      throw DeltaErrors.notADeltaTableException(id)
+    }
+    val partitionPredicates = DeltaDataSource.verifyAndCreatePartitionFilters(
+      path.toString, snapshot, partitionFilters)
+
+    deltaLog.createRelation(
+      partitionPredicates, Some(snapshot), timeTravelSpec.isDefined, options)
+  }
+
+  /**
+   * Check the passed in options and existing timeTravelOpt, set new time travel by options.
+   */
+  def withOptions(options: Map[String, String]): ClickHouseTableV2 = {
+    val ttSpec = DeltaDataSource.getTimeTravelVersion(options)
+    if (timeTravelOpt.nonEmpty && ttSpec.nonEmpty) {
+      throw DeltaErrors.multipleTimeTravelSyntaxUsed
+    }
+    if (timeTravelOpt.isEmpty && ttSpec.nonEmpty) {
+      copy(timeTravelOpt = ttSpec)
+    } else {
+      this
+    }
+  }
+
+  /**
+   * Refresh table to load latest snapshot
+   */
+  def refresh(): Unit = {
+    updateSnapshot(true)
+  }
+
+  def listFiles(partitionFilters: Seq[Expression] = Seq.empty[Expression],
+                partitionColumnPrefixes: Seq[String] = Nil): Seq[AddMergeTreeParts] = {
+    val allParts = ClickHouseTableV2.fileStatusCache.get(this.rootPath)
+    allParts
+  }
+}
+
+object ClickHouseTableV2 {
+  protected var lastUpdateTimestamp: Long = -1L
+  protected val stalenessLimit = SparkSession.active.sessionState.conf.getConf(
+    DeltaSQLConf.DELTA_ASYNC_UPDATE_STALENESS_TIME_LIMIT)
+
+  def isSnapshotStale: Boolean = {
+    stalenessLimit == 0L || lastUpdateTimestamp < 0 ||
+      System.currentTimeMillis() - lastUpdateTimestamp >= stalenessLimit
+  }
+
+  val fileStatusCacheLoader: CacheLoader[Path, Seq[AddMergeTreeParts]] =
+    new CacheLoader[Path, Seq[AddMergeTreeParts]]() {
+      @throws[Exception]
+      override def load(tablePath: Path): Seq[AddMergeTreeParts] = {
+        getTableParts(tablePath)
+      }
+    }
+
+  val fileStatusCache = CacheBuilder.newBuilder
+    .maximumSize(1000)
+    .expireAfterAccess(3600L, TimeUnit.SECONDS)
+    .recordStats.build[Path, Seq[AddMergeTreeParts]](fileStatusCacheLoader)
+
+  def getTableParts(tablePath: Path): Seq[AddMergeTreeParts] = {
+    implicit val enc = SingleAction.addFileEncoder
+    val start = System.currentTimeMillis()
+    val snapshot = ClickHouseLog.forTable(SparkSession.active, tablePath).snapshot
+    val allParts = DeltaLog.filterFileList(
+      snapshot.metadata.partitionSchema,
+      snapshot.allFiles.toDF(),
+      Seq.empty).as[AddFile].collect().map(AddFileTags.partsMapToParts(_))
+      .sortWith(_.minBlockNumber < _.minBlockNumber).toSeq
+    println(s"Get all parts from path ${tablePath.toString} " +
+      (System.currentTimeMillis() - start))
+    allParts
+  }
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/utils/CHDataSourceUtils.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/utils/CHDataSourceUtils.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.utils
+
+import java.util.Locale
+
+import scala.util.Try
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseConfig
+import org.apache.spark.sql.SparkSession
+
+object CHDataSourceUtils {
+
+  def isClickHouseDataSourceName(name: String): Boolean = {
+    name.toLowerCase(Locale.ROOT) == ClickHouseConfig.NAME ||
+      name.toLowerCase(Locale.ROOT) == ClickHouseConfig.ALT_NAME
+  }
+
+  /** Check whether this table is a ClickHouse table based on information from the Catalog. */
+  def isClickHouseTable(provider: Option[String]): Boolean = {
+    provider.exists(isClickHouseDataSourceName)
+  }
+
+  /** Check whether this table is a Delta table based on information from the Catalog. */
+  def isDeltaTable(table: CatalogTable): Boolean =
+    CHDataSourceUtils.isClickHouseTable(table.provider)
+
+  /** Find the root of a Delta table from the provided path. */
+  def findClickHouseTableRoot(
+                          spark: SparkSession,
+                          path: Path,
+                          options: Map[String, String] = Map.empty): Option[Path] = {
+    val fs = path.getFileSystem(spark.sessionState.newHadoopConfWithOptions(options))
+    var currentPath = path
+    while (currentPath != null && currentPath.getName != ClickHouseConfig.METADATA_DIR) {
+      val deltaLogPath = new Path(currentPath, ClickHouseConfig.METADATA_DIR)
+      if (Try(fs.exists(deltaLogPath)).getOrElse(false)) {
+        return Option(currentPath)
+      }
+      currentPath = currentPath.getParent
+    }
+    None
+  }
+}

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/utils/ScanMergeTreePartsUtils.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/utils/ScanMergeTreePartsUtils.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.utils
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.DeltaOperations
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.metadata.AddFileTags
+
+object ScanMergeTreePartsUtils extends Logging {
+
+  def scanMergeTreePartsToAddFile(configuration: Configuration,
+                                  clickHouseTableV2: ClickHouseTableV2): Seq[AddFile] = {
+    // scan parts dir
+    val fs = FileSystem.get(configuration)
+    val scanPath = new Path(clickHouseTableV2.path + "/*_[0-9]*_[0-9]*_[0-9]*")
+    val fileGlobStatuses = fs.globStatus(scanPath)
+    val allDirSummary = fileGlobStatuses.filter(_.isDirectory).map(p => {
+      logInfo(s"scan merge tree parts: ${p.getPath.toString}")
+      val sum = fs.getContentSummary(p.getPath)
+      val pathName = p.getPath.getName
+      val pathNameArr = pathName.split("_")
+      val (partitionId, minBlockNum, maxBlockNum, level) = if (pathNameArr.length == 4) {
+        (pathNameArr(0), pathNameArr(1).toLong, pathNameArr(2).toLong, pathNameArr(3).toInt)
+      } else {
+        ("", 0L, 0L, 0)
+      }
+      (pathName, partitionId, minBlockNum, maxBlockNum, level, sum.getLength, p.getModificationTime)
+    }).filter(!_._2.equals(""))
+
+    // generate CommitInfo and AddFile
+    val versionFileName = FileNames.deltaFile(clickHouseTableV2.deltaLog.logPath, 1)
+    if (fs.exists(versionFileName)) {
+      fs.delete(versionFileName, false)
+    }
+    val finalActions = allDirSummary.map(dir => {
+      AddFileTags.partsInfoToAddFile(clickHouseTableV2.catalogTable.get.identifier.database.get,
+        clickHouseTableV2.catalogTable.get.identifier.table,
+        clickHouseTableV2.snapshot.metadata.configuration.get("engine").get,
+        clickHouseTableV2.deltaLog.dataPath.toString + "/" + dir._1,
+        "", dir._1, "", 0L, dir._6, dir._6, dir._6, dir._7, dir._2, dir._3,
+        dir._4, dir._5, dir._3, true)
+    })
+    if (finalActions.nonEmpty) {
+      // write transaction log
+      logInfo(s"starting to generate commit info, finalActions.length=${finalActions.length} .")
+      clickHouseTableV2.deltaLog.withNewTransaction { txn =>
+        val operation = DeltaOperations.Write(SaveMode.Append, Option(Seq.empty[String]),
+          None, None)
+        txn.commit(finalActions, operation)
+      }
+    }
+    finalActions
+  }
+
+}

--- a/jvm/src/test/scala/com/intel/oap/benchmarks/BenchmarkTest.scala
+++ b/jvm/src/test/scala/com/intel/oap/benchmarks/BenchmarkTest.scala
@@ -122,7 +122,7 @@ object BenchmarkTest {
 
     println(tookTimeArr.mkString(","))
 
-    spark.conf.set("org.apache.spark.example.columnar.enabled", "false")
+    spark.conf.set("spark.oap.sql.enable.native.engine", "false")
     import spark.implicits._
     val df = spark.sparkContext.parallelize(tookTimeArr.toSeq, 1).toDF("time")
     df.summary().show(100, false)

--- a/jvm/src/test/scala/com/intel/oap/benchmarks/DSV2BenchmarkTest.scala
+++ b/jvm/src/test/scala/com/intel/oap/benchmarks/DSV2BenchmarkTest.scala
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.benchmarks
+
+import java.io.File
+
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
+import com.intel.oap.GazelleJniConfig
+
+import org.apache.spark.sql.SparkSession
+
+object DSV2BenchmarkTest {
+
+  val tableName = "lineitem_ch"
+
+  def main(args: Array[String]): Unit = {
+
+    val (parquetFilesPath, fileFormat,
+    executedCnt, configed, sqlFilePath, stopFlagFile,
+    createTable, metaRootPath) = if (args.length > 0) {
+      (args(0), args(1), args(2).toInt, true, args(3), args(4), args(5).toBoolean, args(6))
+    } else {
+      val rootPath = this.getClass.getResource("/").getPath
+      val resourcePath = rootPath + "../../../src/test/resources/"
+      val dataPath = resourcePath + "/tpch-data/"
+      val queryPath = resourcePath + "/queries/"
+      (new File(dataPath).getAbsolutePath, "parquet", 1, false, queryPath + "q06.sql", "", true,
+      "/data1/gazelle-jni-warehouse")
+    }
+
+    val (warehouse, metaStorePathAbsolute, hiveMetaStoreDB) = if (!metaRootPath.isEmpty) {
+      (metaRootPath + "/spark-warehouse", metaRootPath + "/meta",
+        metaRootPath + "/meta/metastore_db")
+    } else {
+      ("/tmp/spark-warehouse", "/tmp/meta", "/tmp/meta/metastore_db")
+    }
+
+    if (!warehouse.isEmpty) {
+      val warehouseDir = new File(warehouse)
+      if (!warehouseDir.exists()) {
+        warehouseDir.mkdirs()
+      }
+      val hiveMetaStoreDBDir = new File(metaStorePathAbsolute)
+      if (!hiveMetaStoreDBDir.exists()) {
+        hiveMetaStoreDBDir.mkdirs()
+      }
+    }
+
+    val sqlStr = Source.fromFile(new File(sqlFilePath), "UTF-8")
+
+    val sessionBuilderTmp = SparkSession
+      .builder()
+      .appName("Gazelle-Jni-Benchmark")
+
+    val sessionBuilder = if (!configed) {
+      val sessionBuilderTmp1 = sessionBuilderTmp
+        .master("local[3]")
+        .config("spark.driver.memory", "4G")
+        .config("spark.driver.memoryOverhead", "6G")
+        .config("spark.serializer", "org.apache.spark.serializer.JavaSerializer")
+        .config("spark.default.parallelism", 1)
+        .config("spark.sql.shuffle.partitions", 1)
+        .config("spark.sql.adaptive.enabled", "false")
+        .config("spark.sql.files.maxPartitionBytes", 1024 << 10 << 10) // default is 128M
+        .config("spark.sql.files.minPartitionNum", "1")
+        .config("spark.sql.parquet.filterPushdown", "true")
+        .config("spark.locality.wait", "0s")
+        .config("spark.sql.sources.ignoreDataLocality", "true")
+        .config("spark.sql.parquet.enableVectorizedReader", "true")
+        //.config("spark.sql.sources.useV1SourceList", "avro")
+        .config("spark.memory.fraction", "0.3")
+        .config("spark.memory.storageFraction", "0.3")
+        //.config("spark.sql.parquet.columnarReaderBatchSize", "20000")
+        .config("spark.plugins", "com.intel.oap.GazellePlugin")
+        .config("spark.sql.catalog.spark_catalog",
+          "org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseSparkCatalog")
+        .config("spark.databricks.delta.maxSnapshotLineageLength", 20)
+        .config("spark.databricks.delta.snapshotPartitions", 1)
+        .config("spark.databricks.delta.properties.defaults.checkpointInterval", 5)
+        .config("spark.databricks.delta.stalenessLimit", 3600 * 1000)
+        //.config("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+        //.config("spark.sql.execution.arrow.maxRecordsPerBatch", "20000")
+        .config("spark.oap.sql.columnar.columnartorow", "false")
+        .config(GazelleJniConfig.OAP_LOAD_NATIVE, "true")
+        .config(GazelleJniConfig.OAP_LOAD_ARROW, "false")
+        .config(GazelleJniConfig.OAP_LIB_PATH,
+          "path_to_clickhouse_engine/libch.so")
+        .config("spark.oap.sql.columnar.iterator", "false")
+        //.config("spark.sql.planChangeLog.level", "info")
+        .config("spark.sql.columnVector.offheap.enabled", "true")
+        .config("spark.memory.offHeap.enabled", "true")
+        .config("spark.memory.offHeap.size", "6442450944")
+
+      if (!warehouse.isEmpty) {
+        sessionBuilderTmp1.config("spark.sql.warehouse.dir", warehouse)
+          .config("javax.jdo.option.ConnectionURL", s"jdbc:derby:;databaseName=$hiveMetaStoreDB;create=true")
+          .enableHiveSupport()
+      } else {
+        sessionBuilderTmp1.enableHiveSupport()
+      }
+    } else {
+      sessionBuilderTmp
+    }
+
+    val spark = sessionBuilder.getOrCreate()
+    if (!configed) {
+      //spark.sparkContext.setLogLevel("WARN")
+    }
+
+    val createTbl = true
+    if (createTbl) {
+      createClickHouseTables(spark, parquetFilesPath, fileFormat)
+      createLocationClickHouseTable(spark)
+    }
+    val refreshTable = true
+    if (refreshTable) {
+      refreshClickHouseTable(spark)
+    }
+    selectClickHouseTable(spark, executedCnt, sqlStr.mkString)
+    selectLocationClickHouseTable(spark, executedCnt, sqlStr.mkString)
+
+    System.out.println("waiting for finishing")
+    if (stopFlagFile.isEmpty) {
+      Thread.sleep(1800000)
+    } else {
+      while ((new File(stopFlagFile)).exists()) {
+        Thread.sleep(1000)
+      }
+    }
+    spark.stop()
+    System.out.println("finished")
+  }
+
+  def createClickHouseTables(spark: SparkSession,
+                             parquetFilesPath: String, fileFormat: String): Unit = {
+    spark.sql(
+      """
+        | show databases
+        |""".stripMargin).show(100, false)
+
+    spark.sql(
+      """
+        | show tables
+        |""".stripMargin).show(100, false)
+
+    spark.sql(
+      s"""
+         | USE default
+         |""".stripMargin).show(100, false)
+
+    // Clear up old session
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    // Create a table
+    println("Creating a table")
+    // PARTITIONED BY (age)
+    // engine='MergeTree' or engine='Parquet'
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS $tableName (
+         | l_orderkey      bigint,
+         | l_partkey       bigint,
+         | l_suppkey       bigint,
+         | l_linenumber    bigint,
+         | l_quantity      double,
+         | l_extendedprice double,
+         | l_discount      double,
+         | l_tax           double,
+         | l_returnflag    string,
+         | l_linestatus    string,
+         | l_shipdate      date,
+         | l_commitdate    date,
+         | l_receiptdate   date,
+         | l_shipinstruct  string,
+         | l_shipmode      string,
+         | l_comment       string)
+         | USING clickhouse
+         | TBLPROPERTIES (engine='MergeTree'
+         |                )
+         |""".stripMargin)
+
+    spark.sql(
+      """
+        | show tables
+        |""".stripMargin).show(100, false)
+
+    spark.sql(
+      s"""
+         | desc formatted ${tableName}
+         |""".stripMargin).show(100, false)
+
+  }
+
+  def createLocationClickHouseTable(spark: SparkSession): Unit = {
+    spark.sql(
+      s"""
+         | USE default
+         |""".stripMargin).show(100, false)
+
+    spark.sql(
+      """
+        | show tables
+        |""".stripMargin).show(100, false)
+
+    // Clear up old session
+    spark.sql(s"DROP TABLE IF EXISTS ch_clickhouse")
+
+    // Create a table
+    // PARTITIONED BY (age)
+    // engine='MergeTree' or engine='Parquet'
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS ch_clickhouse (
+         | l_orderkey      bigint,
+         | l_partkey       bigint,
+         | l_suppkey       bigint,
+         | l_linenumber    bigint,
+         | l_quantity      double,
+         | l_extendedprice double,
+         | l_discount      double,
+         | l_tax           double,
+         | l_returnflag    string,
+         | l_linestatus    string,
+         | l_shipdate      date,
+         | l_commitdate    date,
+         | l_receiptdate   date,
+         | l_shipinstruct  string,
+         | l_shipmode      string,
+         | l_comment       string)
+         | USING clickhouse
+         | TBLPROPERTIES (engine='MergeTree'
+         |                )
+         | LOCATION '/data1/gazelle-jni-warehouse/ch_clickhouse'
+         |""".stripMargin)
+
+    spark.sql(
+      """
+        | show tables
+        |""".stripMargin).show(100, false)
+  }
+
+  def refreshClickHouseTable(spark: SparkSession): Unit = {
+    spark.sql(
+      s"""
+         | refresh table ${tableName}
+         |""".stripMargin).show(100, false)
+    spark.sql(
+      s"""
+         | desc formatted ${tableName}
+         |""".stripMargin).show(100, false)
+    spark.sql(
+      s"""
+         | refresh table ch_clickhouse
+         |""".stripMargin).show(100, false)
+    spark.sql(
+      s"""
+         | desc formatted ch_clickhouse
+         |""".stripMargin).show(100, false)
+  }
+
+  def selectClickHouseTable(spark: SparkSession, executedCnt: Int,
+                            sql: String): Unit = {
+    val tookTimeArr = ArrayBuffer[Long]()
+    for (i <- 1 to executedCnt) {
+      val startTime = System.nanoTime()
+      spark.sql(
+        s"""
+          |SELECT
+          |    sum(l_extendedprice * l_discount) AS revenue
+          |FROM
+          |    ${tableName}
+          |WHERE
+          |    l_shipdate >= date'1994-01-01'
+          |    AND l_shipdate < date'1994-01-01' + interval 1 year
+          |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
+          |    AND l_quantity < 24;
+          |""".stripMargin).show(200, false)
+      val tookTime = (System.nanoTime() - startTime) / 1000000
+      println(s"Execute ${i} time, time: ${tookTime}")
+      tookTimeArr += tookTime
+    }
+
+    println(tookTimeArr.mkString(","))
+
+    //spark.conf.set("spark.oap.sql.enable.native.engine", "false")
+    import spark.implicits._
+    val df = spark.sparkContext.parallelize(tookTimeArr.toSeq, 1).toDF("time")
+    df.summary().show(100, false)
+  }
+
+  def selectLocationClickHouseTable(spark: SparkSession, executedCnt: Int,
+                            sql: String): Unit = {
+    val tookTimeArr = ArrayBuffer[Long]()
+    for (i <- 1 to executedCnt) {
+      val startTime = System.nanoTime()
+      spark.sql(
+        s"""
+           |SELECT
+           |    sum(l_extendedprice * l_discount) AS revenue
+           |FROM
+           |    ch_clickhouse
+           |WHERE
+           |    l_shipdate >= date'1994-01-01'
+           |    AND l_shipdate < date'1994-01-01' + interval 1 year
+           |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
+           |    AND l_quantity < 24;
+           |""".stripMargin).show(200, false)
+      val tookTime = (System.nanoTime() - startTime) / 1000000
+      println(s"Execute ${i} time, time: ${tookTime}")
+      tookTimeArr += tookTime
+    }
+
+    println(tookTimeArr.mkString(","))
+
+    //spark.conf.set("spark.oap.sql.enable.native.engine", "false")
+    import spark.implicits._
+    val df = spark.sparkContext.parallelize(tookTimeArr.toSeq, 1).toDF("time")
+    df.summary().show(100, false)
+  }
+}

--- a/jvm/src/test/scala/com/intel/oap/benchmarks/TableBenchmarkTest.scala
+++ b/jvm/src/test/scala/com/intel/oap/benchmarks/TableBenchmarkTest.scala
@@ -92,9 +92,6 @@ object TableBenchmarkTest {
         .config("spark.oap.sql.columnar.columnartorow", "false")
         .config(GazelleJniConfig.OAP_LOAD_NATIVE, "true")
         .config(GazelleJniConfig.OAP_LOAD_ARROW, "false")
-        // /home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-MergeTree/cmake-build-release/utils/local-engine/liblocal_engine_jni.so
-        // /home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse/cmake-build-release/utils/local-engine/liblocal_engine_jni.so
-        // /home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-MergeTree/cmake-build-debug/utils/local-engine/liblocal_engine_jnid.so
         .config(GazelleJniConfig.OAP_LIB_PATH,
           "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-MergeTree/cmake-build-release/utils/local-engine/liblocal_engine_jni.so")
         .config("spark.oap.sql.columnar.iterator", "false")
@@ -165,7 +162,7 @@ object TableBenchmarkTest {
 
     println(tookTimeArr.mkString(","))
 
-    spark.conf.set("org.apache.spark.example.columnar.enabled", "false")
+    spark.conf.set("spark.oap.sql.enable.native.engine", "false")
     import spark.implicits._
     val df = spark.sparkContext.parallelize(tookTimeArr.toSeq, 1).toDF("time")
     df.summary().show(100, false)

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,22 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>io.delta</groupId>
+        <artifactId>delta-core_${scala.binary.version}</artifactId>
+        <version>1.0.1</version>
+        <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.antlr</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
         <version>3.2.3</version>


### PR DESCRIPTION
Support to use ClickHouse Spark DataSource V2 to : 
1. create ClickHouse tables;
2. refresh tables;
3. query tables (TPCH-Q6);

To enabled this feature, add this conf in spark:
spark.sql.catalog.spark_catalog=org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseSparkCatalog

Write ClickHouse MergeTree data with Spark DataSource V2 will be implemented on Phase two.

To enable native engine, below option should be added:
--conf spark.oap.sql.enable.native.engine=true

Closes #90 