### PR TITLE
[GJ-96] Enable hash partitioning in columnar shuffle

### DIFF
--- a/cpp/src/compute/substrait_to_velox_expr.cc
+++ b/cpp/src/compute/substrait_to_velox_expr.cc
@@ -16,6 +16,7 @@
  */
 
 #include "substrait_to_velox_expr.h"
+
 #include "type_utils.h"
 
 using namespace facebook::velox;

--- a/cpp/src/compute/substrait_to_velox_plan.cc
+++ b/cpp/src/compute/substrait_to_velox_plan.cc
@@ -647,18 +647,14 @@ class SubstraitVeloxPlanConverter::WholeStageResIter
             bytesOfType(col_type) * num_rows);
         out_data.buffers[1] = data_buffer;
       } else if (isString(col_type)) {
-        auto offsets = static_cast<const uint32_t*>(arrowArray.buffers[2]);
-        auto string_data_size = offsets[num_rows];
+        auto offsets = static_cast<const int32_t*>(arrowArray.buffers[1]);
+        int32_t string_data_size = offsets[num_rows];
         auto value_buffer = std::make_shared<arrow::Buffer>(
-            static_cast<const uint8_t*>(arrowArray.buffers[1]), string_data_size);
+            static_cast<const uint8_t*>(arrowArray.buffers[2]), string_data_size);
         auto offset_bytes = sizeof(int32_t);
         auto offset_buffer = std::make_shared<arrow::Buffer>(
-            static_cast<const uint8_t*>(arrowArray.buffers[2]),
+            static_cast<const uint8_t*>(arrowArray.buffers[1]),
             offset_bytes * (num_rows + 1));
-        /* Velox:                     Arrow:
-           buffer_1 -> value          buffer_1 -> offset
-           buffer_2 -> offset         buffer_2 -> value
-        */
         out_data.buffers[1] = offset_buffer;
         out_data.buffers[2] = value_buffer;
       }

--- a/cpp/src/compute/substrait_to_velox_plan.h
+++ b/cpp/src/compute/substrait_to_velox_plan.h
@@ -46,6 +46,11 @@ class SubstraitVeloxPlanConverter {
  public:
   SubstraitVeloxPlanConverter();
 
+  /// This method is used to create a Project node as the parent of Aggregation node,
+  /// in order to unify the plan node id in column names.
+  std::shared_ptr<const core::PlanNode> createUnifyNode(
+      const std::shared_ptr<const core::PlanNode>& aggNode, uint64_t groupingSize,
+      uint64_t aggSize);
   std::shared_ptr<const core::PlanNode> toVeloxPlan(
       const substrait::AggregateRel& sagg,
       std::vector<arrow::RecordBatchIterator> arrow_iters);

--- a/cpp/src/jni/jni_common.h
+++ b/cpp/src/jni/jni_common.h
@@ -334,8 +334,9 @@ arrow::Status MakeExprVector(JNIEnv* env, jbyteArray exprs_arr,
   return arrow::Status::OK();
 }
 
+template <typename T>
 arrow::Status getSubstraitPlan(JNIEnv* env, jbyteArray exprs_arr,
-                               substrait::Plan* outPlan) {
+                               T* outPlan) {
   jsize exprs_len = env->GetArrayLength(exprs_arr);
   jbyte* exprs_bytes = env->GetByteArrayElements(exprs_arr, 0);
 #ifdef DEBUG

--- a/cpp/src/jni/jni_common.h
+++ b/cpp/src/jni/jni_common.h
@@ -335,8 +335,7 @@ arrow::Status MakeExprVector(JNIEnv* env, jbyteArray exprs_arr,
 }
 
 template <typename T>
-arrow::Status getSubstraitPlan(JNIEnv* env, jbyteArray exprs_arr,
-                               T* outPlan) {
+arrow::Status getSubstraitPlan(JNIEnv* env, jbyteArray exprs_arr, T* outPlan) {
   jsize exprs_len = env->GetArrayLength(exprs_arr);
   jbyte* exprs_bytes = env->GetByteArrayElements(exprs_arr, 0);
 #ifdef DEBUG

--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -193,13 +193,13 @@ class JavaRecordBatchIterator {
     JNIEnv* env;
     int getEnvStat = vm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION);
     if (getEnvStat == JNI_EDETACHED) {
-#ifdef DEBUG    
+#ifdef DEBUG
       std::cout << "JNIEnv was not attached to current thread." << std::endl;
 #endif
       if (vm_->AttachCurrentThread(reinterpret_cast<void**>(&env), NULL) != 0) {
         return arrow::Status::Invalid("Failed to attach thread.");
-      } else {       
-#ifdef DEBUG       
+      } else {
+#ifdef DEBUG
         std::cout << "Succeeded attaching current thread." << std::endl;
 #endif
       }
@@ -665,8 +665,7 @@ Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_nativeMake(
 
   substrait::Rel subRel;
   if (expr_arr != NULL) {
-    JniAssertOkOrThrow(
-      getSubstraitPlan<substrait::Rel>(env, expr_arr, &subRel),
+    JniAssertOkOrThrow(getSubstraitPlan<substrait::Rel>(env, expr_arr, &subRel),
                        "Failed to parse expressions protobuf");
   }
   jclass cls = env->FindClass("java/lang/Thread");

--- a/cpp/src/operators/c2r/velox_to_row_converter.cc
+++ b/cpp/src/operators/c2r/velox_to_row_converter.cc
@@ -16,13 +16,13 @@
  */
 
 #include "velox_to_row_converter.h"
-#include "compute/type_utils.h"
 
 #include <arrow/array/array_base.h>
 #include <arrow/buffer.h>
 #include <arrow/type_traits.h>
 
 #include "arrow/c/Bridge.h"
+#include "compute/type_utils.h"
 #include "conversion_utils.h"
 #include "velox/row/UnsafeRowDynamicSerializer.h"
 #include "velox/row/UnsafeRowSerializer.h"

--- a/cpp/src/operators/shuffle/splitter.cc
+++ b/cpp/src/operators/shuffle/splitter.cc
@@ -244,10 +244,9 @@ class Splitter::PartitionWriter {
 
 arrow::Result<std::shared_ptr<Splitter>> Splitter::Make(
     const std::string& short_name, std::shared_ptr<arrow::Schema> schema,
-    int num_partitions, const gandiva::ExpressionVector& expr_vector,
-    SplitOptions options) {
+    int num_partitions, const substrait::Rel& subRel, SplitOptions options) {
   if (short_name == "hash") {
-    return HashSplitter::Create(num_partitions, std::move(schema), expr_vector,
+    return HashSplitter::Create(num_partitions, std::move(schema), subRel,
                                 std::move(options));
   } else if (short_name == "rr") {
     return RoundRobinSplitter::Create(num_partitions, std::move(schema),
@@ -1317,50 +1316,50 @@ arrow::Status RoundRobinSplitter::ComputeAndCountPartitionId(
 
 arrow::Result<std::shared_ptr<HashSplitter>> HashSplitter::Create(
     int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
-    const gandiva::ExpressionVector& expr_vector, SplitOptions options) {
+    const substrait::Rel& subRel, SplitOptions options) {
   std::shared_ptr<HashSplitter> res(
       new HashSplitter(num_partitions, std::move(schema), std::move(options)));
   RETURN_NOT_OK(res->Init());
-  RETURN_NOT_OK(res->CreateProjector(expr_vector));
+  RETURN_NOT_OK(res->CreateHasher(subRel));
   return res;
 }
 
-arrow::Status HashSplitter::CreateProjector(
-    const gandiva::ExpressionVector& expr_vector) {
-  // same seed as spark's
-  auto hash = gandiva::TreeExprBuilder::MakeLiteral((int32_t)42);
-  for (const auto& expr : expr_vector) {
-    switch (expr->root()->return_type()->id()) {
-      case arrow::NullType::type_id:
+arrow::Status HashSplitter::CreateHasher(const substrait::Rel& subRel) {
+  // Parse the ProjectRel to get hash expression.
+  // Currently, only filed is supported.
+  substrait::ProjectRel subProject;
+  if (subRel.has_project()) {
+    subProject = subRel.project();
+  }
+  for (auto& sexpr : subProject.expressions()) {
+    switch (sexpr.rex_type_case()) {
+      case substrait::Expression::RexTypeCase::kSelection: {
+        auto sfield = sexpr.selection();
+        switch (sfield.reference_type_case()) {
+          case substrait::Expression::FieldReference::ReferenceTypeCase::
+              kDirectReference: {
+            auto sref = sfield.direct_reference();
+            switch (sref.reference_type_case()) {
+              case substrait::Expression::ReferenceSegment::ReferenceTypeCase::
+                  kStructField: {
+                hashIndices_.push_back(sref.struct_field().field());
+                break;
+              }
+              default:
+                return arrow::Status::Invalid("Unrecognized reference.");
+            }
+            break;
+          }
+          default:
+            return arrow::Status::Invalid("Unrecognized expression.");
+        }
         break;
-      case arrow::BooleanType::type_id:
-      case arrow::Int8Type::type_id:
-      case arrow::Int16Type::type_id:
-      case arrow::Int32Type::type_id:
-      case arrow::FloatType::type_id:
-      case arrow::Date32Type::type_id:
-        hash = gandiva::TreeExprBuilder::MakeFunction(
-            "hash32_spark", {expr->root(), hash}, arrow::int32());
-        break;
-      case arrow::Int64Type::type_id:
-      case arrow::DoubleType::type_id:
-        hash = gandiva::TreeExprBuilder::MakeFunction(
-            "hash64_spark", {expr->root(), hash}, arrow::int32());
-        break;
-      case arrow::StringType::type_id:
-        hash = gandiva::TreeExprBuilder::MakeFunction(
-            "hashbuf_spark", {expr->root(), hash}, arrow::int32());
-        break;
+      }
       default:
-        hash = gandiva::TreeExprBuilder::MakeFunction("hash32", {expr->root(), hash},
-                                                      arrow::int32());
-        /*return arrow::Status::NotImplemented("HashSplitter::CreateProjector
-           doesn't support type ", expr->result()->type()->ToString());*/
+        return arrow::Status::Invalid("Only Fields are supported as hash keys.");
     }
   }
-  auto hash_expr =
-      gandiva::TreeExprBuilder::MakeExpression(hash, arrow::field("pid", arrow::int32()));
-  return gandiva::Projector::Make(schema_, {hash_expr}, &projector_);
+  return arrow::Status::OK();
 }
 
 arrow::Status HashSplitter::ComputeAndCountPartitionId(const arrow::RecordBatch& rb) {
@@ -1368,17 +1367,8 @@ arrow::Status HashSplitter::ComputeAndCountPartitionId(const arrow::RecordBatch&
   partition_id_.resize(num_rows);
   std::fill(std::begin(partition_id_cnt_), std::end(partition_id_cnt_), 0);
 
-  arrow::ArrayVector outputs;
-  TIME_NANO_OR_RAISE(total_compute_pid_time_,
-                     projector_->Evaluate(rb, options_.memory_pool, &outputs));
-  if (outputs.size() != 1) {
-    return arrow::Status::Invalid("Projector result should have one field, actual is ",
-                                  std::to_string(outputs.size()));
-  }
-  auto pid_arr = std::dynamic_pointer_cast<arrow::Int32Array>(outputs.at(0));
-  if (pid_arr == nullptr) {
-    return arrow::Status::Invalid("failed to cast outputs.at(0)");
-  }
+  std::shared_ptr<arrow::Int32Array> pid_arr;
+  // Calculate hash value.
   for (auto i = 0; i < num_rows; ++i) {
     // positive mod
     auto pid = pid_arr->Value(i) % num_partitions_;

--- a/cpp/src/operators/shuffle/splitter.h
+++ b/cpp/src/operators/shuffle/splitter.h
@@ -256,13 +256,18 @@ class HashSplitter : public Splitter {
  private:
   HashSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
                SplitOptions options)
-      : Splitter(num_partitions, std::move(schema), std::move(options)) {}
+      : Splitter(num_partitions, schema, std::move(options)), schema_(schema) {}
 
-  arrow::Status CreateHasher(const substrait::Rel& subRel);
+  arrow::Status CreateGandivaExpr(const substrait::Rel& subRel);
+
+  arrow::Status CreateProjector();
 
   arrow::Status ComputeAndCountPartitionId(const arrow::RecordBatch& rb) override;
 
   std::vector<u_int32_t> hashIndices_;
+  std::shared_ptr<arrow::Schema> schema_;
+  gandiva::ExpressionVector exprVector_;
+  std::shared_ptr<gandiva::Projector> projector_;
 };
 
 class FallbackRangeSplitter : public Splitter {

--- a/cpp/src/operators/shuffle/splitter.h
+++ b/cpp/src/operators/shuffle/splitter.h
@@ -30,6 +30,7 @@
 
 #include "operators/shuffle/type.h"
 #include "operators/shuffle/utils.h"
+#include "substrait/algebra.pb.h"
 
 namespace gazellejni {
 namespace shuffle {
@@ -38,7 +39,7 @@ class Splitter {
  public:
   static arrow::Result<std::shared_ptr<Splitter>> Make(
       const std::string& short_name, std::shared_ptr<arrow::Schema> schema,
-      int num_partitions, const gandiva::ExpressionVector& expr_vector,
+      int num_partitions, const substrait::Rel& subRel,
       SplitOptions options = SplitOptions::Defaults());
 
   static arrow::Result<std::shared_ptr<Splitter>> Make(
@@ -250,18 +251,18 @@ class HashSplitter : public Splitter {
  public:
   static arrow::Result<std::shared_ptr<HashSplitter>> Create(
       int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
-      const gandiva::ExpressionVector& expr_vector, SplitOptions options);
+      const substrait::Rel& subRel, SplitOptions options);
 
  private:
   HashSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
                SplitOptions options)
       : Splitter(num_partitions, std::move(schema), std::move(options)) {}
 
-  arrow::Status CreateProjector(const gandiva::ExpressionVector& expr_vector);
+  arrow::Status CreateHasher(const substrait::Rel& subRel);
 
   arrow::Status ComputeAndCountPartitionId(const arrow::RecordBatch& rb) override;
 
-  std::shared_ptr<gandiva::Projector> projector_;
+  std::vector<u_int32_t> hashIndices_;
 };
 
 class FallbackRangeSplitter : public Splitter {

--- a/jvm/src/main/scala/com/intel/oap/expression/UnaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/com/intel/oap/expression/UnaryOperatorTransformer.scala
@@ -74,49 +74,63 @@ class MonthTransformer(child: Expression, original: Expression)
     extends Month(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class DayOfMonthTransformer(child: Expression, original: Expression)
   extends DayOfMonth(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class YearTransformer(child: Expression, original: Expression)
   extends Year(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class NotTransformer(child: Expression, original: Expression)
     extends Not(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class AbsTransformer(child: Expression, original: Expression)
     extends Abs(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class UpperTransformer(child: Expression, original: Expression)
     extends Upper(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class BitwiseNotTransformer(child: Expression, original: Expression)
     extends BitwiseNot(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class CheckOverflowTransformer(child: Expression, original: CheckOverflow)
@@ -126,7 +140,9 @@ class CheckOverflowTransformer(child: Expression, original: CheckOverflow)
       original.nullOnOverflow: Boolean)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class CastTransformer(
@@ -156,7 +172,9 @@ class UnscaledValueTransformer(child: Expression, original: Expression)
     extends UnscaledValue(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class MakeDecimalTransformer(
@@ -168,14 +186,23 @@ class MakeDecimalTransformer(
     extends MakeDecimal(child: Expression, precision: Int, scale: Int, nullOnOverflow: Boolean)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    throw new UnsupportedOperationException("Not supported.")
+  }
 }
 
 class NormalizeNaNAndZeroTransformer(child: Expression, original: NormalizeNaNAndZero)
     extends NormalizeNaNAndZero(child: Expression)
     with ExpressionTransformer
     with Logging {
-  override def doTransform(args: java.lang.Object): ExpressionNode = null
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    // Not supported currently.
+    val child_node = child.asInstanceOf[ExpressionTransformer].doTransform(args)
+    if (!child_node.isInstanceOf[ExpressionNode]) {
+      throw new UnsupportedOperationException(s"not supported yet")
+    }
+    child_node
+  }
 }
 
 object UnaryOperatorTransformer {


### PR DESCRIPTION
This pr:

- enabled hash partitioning in Coumnar Shuffle
- fixed velox to arrow format issue in string column
- refined the logic in unify node

Closes https://github.com/oap-project/gazelle-jni/issues/96.
